### PR TITLE
Jalon 1 FIX - PYTHONPATH backend pour import app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           backend/.venv/Scripts/python -m ruff check backend
           backend/.venv/Scripts/python -m mypy backend
       - name: Tests
+        env:
+          PYTHONPATH: backend
         run: |
           backend/.venv/Scripts/python -m pytest -q --disable-warnings --maxfail=1
   frontend:

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -5,9 +5,14 @@ Set-StrictMode -Version Latest
 Write-Host "[test_all] Lints + Tests..." -ForegroundColor Cyan
 
 $venv = Join-Path "backend" ".venv"
-& (Join-Path $venv "Scripts\python.exe") -m ruff check backend
-& (Join-Path $venv "Scripts\python.exe") -m mypy backend
-& (Join-Path $venv "Scripts\pytest.exe") -q --maxfail=1 --disable-warnings --cov=backend --cov-report=xml:coverage.xml
+$py = Join-Path $venv "Scripts\python.exe"
+
+& $py -m ruff check backend
+& $py -m mypy backend
+
+# Ensure PYTHONPATH=backend for app imports
+$Env:PYTHONPATH = "backend"
+& $py -m pytest -q --maxfail=1 --disable-warnings --cov=backend --cov-report=xml:coverage.xml
 
 Push-Location "frontend"
 npm run lint

--- a/backend/README.md
+++ b/backend/README.md
@@ -18,6 +18,13 @@ Ouvrir [http://localhost:8000/healthz](http://localhost:8000/healthz)
 pytest -q backend/tests/test_healthz.py
 ```
 
+### Imports et PYTHONPATH
+
+Les tests importent app.main. Il faut que backend/ soit dans PYTHONPATH.
+
+* En local, c est gere par backend/conftest.py.
+* En CI et scripts PS1, on exporte PYTHONPATH=backend avant pytest.
+
 ### CI Gates actifs
 
 * ruff

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Add backend/ to PYTHONPATH for 'from app import ...'
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)


### PR DESCRIPTION
## Summary
- ensure app imports by prepending backend to sys.path during tests
- set PYTHONPATH for backend tests in CI and PowerShell script
- document PYTHONPATH usage in backend README

## Testing
- `backend/.venv/bin/python -m ruff check backend`
- `backend/.venv/bin/python -m mypy backend`
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest -q backend/tests/test_healthz.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad6f862cbc8330a2776586a8659e81