### PR TITLE
Jalon 2 - DB + Alembic (init, head, tests up/down). Relire docs/roadmap.md.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ REQUEST_ID_HEADER=X-Request-ID
 
 # Database (dev local; aucun secret en dur)
 
+DATABASE_URL=postgresql+psycopg://cc_user:cc_pass@localhost:5432/cc_dev
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=cc_dev

--- a/PS1/init_repo.ps1
+++ b/PS1/init_repo.ps1
@@ -25,6 +25,7 @@ if (-not (Test-Path $venv)) {
     python -m venv $venv
 }
 & (Join-Path $venv "Scripts\pip.exe") install -U pip
+# Installe dependances backend (incluant SQLAlchemy + Alembic)
 & (Join-Path $venv "Scripts\pip.exe") install -r (Join-Path "backend" "requirements.txt")
 
 # Frontend install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coulisses Crew (Monorepo, Jalon 0)
+# Coulisses Crew (Monorepo, Jalon 2)
 
 Badges: (CI), (coverage) a ajouter des jalons suivants.
 

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,1 +1,33 @@
-# Placeholder jalon 0
+[alembic]
+script_location = alembic
+sqlalchemy.url = %(DB_URL)s
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = logging.StreamHandler
+args = (sys.stdout,)
+
+[formatter_generic]
+format = %(levelname)s %(name)s %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+# Config Alembic
+
+config = context.config
+
+# Logging config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# URL prioritaire: env DATABASE_URL sinon valeur d env alembic DB_URL sinon fallback SQLite
+
+db_url = os.getenv("DATABASE_URL") or os.getenv("DB_URL") or "sqlite:///./backend/dev.db"
+config.set_main_option("sqlalchemy.url", db_url)
+
+# Pas d autogenerate au jalon 2 (schema min gere via operations scripts)
+
+target_metadata = None
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        literal_binds=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        future=True,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/0001_init_schema_meta.py
+++ b/backend/alembic/versions/0001_init_schema_meta.py
@@ -1,0 +1,25 @@
+"""init schema_meta minimal jalon 2
+"""
+from __future__ import annotations
+from alembic import op
+import sqlalchemy as sa
+
+# Revision identifiers
+
+revision = "0001_init_schema_meta"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        "schema_meta",
+        sa.Column("id", sa.Integer, primary_key=True, nullable=False),
+        sa.Column("key", sa.String(length=64), nullable=False, unique=True),
+        sa.Column("value", sa.String(length=256), nullable=False),
+    )
+    op.create_index("ix_schema_meta_key", "schema_meta", ["key"], unique=True)
+
+def downgrade() -> None:
+    op.drop_index("ix_schema_meta_key", table_name="schema_meta")
+    op.drop_table("schema_meta")

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import os
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, DeclarativeBase
+
+# DATABASE_URL prioritaire, fallback SQLite fichier pour CI jalon 2
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./backend/dev.db")
+
+class Base(DeclarativeBase):
+    pass
+
+engine = create_engine(
+    DATABASE_URL,
+    echo=False,
+    future=True,
+)
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+@contextmanager
+def session_scope() -> Generator:
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def get_db() -> Generator:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,9 +2,16 @@ fastapi==0.115.0
 uvicorn==0.30.6
 pydantic==2.9.2
 requests==2.32.3
-httpx==0.28.1
+typer==0.12.5
+
+# DB & migrations
+SQLAlchemy==2.0.34
+alembic==1.13.2
+
+# Dev
 ruff==0.12.10
 mypy==1.17.1
 pytest==8.4.1
 pytest-cov==6.2.1
 types-requests==2.32.4.20250809
+httpx==0.28.1

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+TEST_DB_PATH = Path("backend/test_migrations.db").resolve()
+TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
+
+def _alembic_config_with_url(db_url: str) -> Config:
+    cfg = Config("backend/alembic.ini")
+    cfg.set_main_option("script_location", "backend/alembic")
+    # Variable d env attendue par alembic.ini (DB_URL)
+    os.environ["DB_URL"] = db_url
+    return cfg
+
+def setup_module(module) -> None:  # noqa: ANN001
+    # Nettoyage ancien fichier
+    if TEST_DB_PATH.exists():
+        TEST_DB_PATH.unlink(missing_ok=True)
+
+def teardown_module(module) -> None:  # noqa: ANN001
+    if TEST_DB_PATH.exists():
+        TEST_DB_PATH.unlink(missing_ok=True)
+
+def test_upgrade_and_downgrade_base() -> None:
+    cfg = _alembic_config_with_url(TEST_DB_URL)
+    # Upgrade head
+    command.upgrade(cfg, "head")
+    # Verifier existence de la table
+    engine = create_engine(TEST_DB_URL, future=True)
+    with engine.connect() as conn:
+        res = conn.execute(
+            text("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'")
+        ).fetchone()
+        assert res is not None, "schema_meta devrait exister apres upgrade"
+
+    # Downgrade base
+    command.downgrade(cfg, "base")
+    with engine.connect() as conn:
+        res = conn.execute(
+            text("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'")
+        ).fetchone()
+        assert res is None, "schema_meta ne devrait plus exister apres downgrade"


### PR DESCRIPTION
## Summary
- init SQLAlchemy engine and Alembic scaffolding
- add first migration with schema_meta table and tests for upgrade/downgrade
- document Alembic usage and update requirements/env

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/init_repo.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68ad72e11d908330829d9f1b6f06dc7b