### PR TITLE
Jalon 2 FIX - Alembic/SQLite: liberer verrous Windows (dispose + retry). Relire docs/roadmap.md.

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -39,10 +39,18 @@ def run_migrations_online() -> None:
         poolclass=pool.NullPool,
         future=True,
     )
-    with connectable.connect() as connection:
-        context.configure(connection=connection)
-        with context.begin_transaction():
-            context.run_migrations()
+    try:
+        with connectable.connect() as connection:
+            context.configure(connection=connection)
+            with context.begin_transaction():
+                context.run_migrations()
+    finally:
+        # Important sous Windows/SQLite: libere les poignees de fichiers
+        try:
+            connectable.dispose()
+        except Exception:
+            # Pas bloquant: on evite d echouer le pipeline si la disposal echoue
+            pass
 
 if context.is_offline_mode():
     run_migrations_offline()

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+import gc
 import os
+import time
 from pathlib import Path
 
 from alembic import command
@@ -16,31 +18,54 @@ def _alembic_config_with_url(db_url: str) -> Config:
     os.environ["DB_URL"] = db_url
     return cfg
 
+def _unlink_with_retry(p: Path, attempts: int = 10, delay_s: float = 0.1) -> None:
+    for _ in range(attempts):
+        try:
+            p.unlink(missing_ok=True)
+            return
+        except PermissionError:
+            gc.collect()
+            time.sleep(delay_s)
+    # Derniere tentative explicite (laissera l erreur si encore verrouille)
+    p.unlink(missing_ok=True)
+
 def setup_module(module) -> None:  # noqa: ANN001
-    # Nettoyage ancien fichier
     if TEST_DB_PATH.exists():
-        TEST_DB_PATH.unlink(missing_ok=True)
+        _unlink_with_retry(TEST_DB_PATH)
 
 def teardown_module(module) -> None:  # noqa: ANN001
     if TEST_DB_PATH.exists():
-        TEST_DB_PATH.unlink(missing_ok=True)
+        _unlink_with_retry(TEST_DB_PATH)
 
 def test_upgrade_and_downgrade_base() -> None:
     cfg = _alembic_config_with_url(TEST_DB_URL)
+
     # Upgrade head
     command.upgrade(cfg, "head")
-    # Verifier existence de la table
+
+    # Verifier existence de la table avec un engine dedie
     engine = create_engine(TEST_DB_URL, future=True)
-    with engine.connect() as conn:
-        res = conn.execute(
-            text("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'")
-        ).fetchone()
-        assert res is not None, "schema_meta devrait exister apres upgrade"
+    try:
+        with engine.connect() as conn:
+            res = conn.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'")
+            ).fetchone()
+            assert res is not None, "schema_meta devrait exister apres upgrade"
+    finally:
+        # Libere le handle de fichier sous Windows/SQLite
+        engine.dispose()
 
     # Downgrade base
     command.downgrade(cfg, "base")
-    with engine.connect() as conn:
-        res = conn.execute(
-            text("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'")
-        ).fetchone()
-        assert res is None, "schema_meta ne devrait plus exister apres downgrade"
+
+    # Nouveau engine pour verifier suppression
+    engine2 = create_engine(TEST_DB_URL, future=True)
+    try:
+        with engine2.connect() as conn:
+            res = conn.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'")
+            ).fetchone()
+            assert res is None, "schema_meta ne devrait plus exister apres downgrade"
+    finally:
+        engine2.dispose()
+

--- a/docs/OPS_WINDOWS.md
+++ b/docs/OPS_WINDOWS.md
@@ -1,2 +1,13 @@
 * Lancer les scripts PowerShell en mode NoProfile.
 * En cas de port occupe, fermer les processus node/uvicorn via dev_down.ps1.
+* Utiliser `Join-Path` et encodage UTF-8 dans les scripts PS1.
+* Python: preferer venv local `backend/.venv`.
+
+## SQLite sur Windows: verrous de fichiers
+
+Sous Windows, SQLite peut garder des verrous de fichiers si des connexions/engines ne sont pas entierement liberes. Mesures appliquees:
+
+* Alembic `env.py`: appel explicite a `connectable.dispose()` apres `run_migrations_online()`.
+* Tests migrations: fermeture du `engine` avec `dispose()` et suppression du fichier de test via `_unlink_with_retry()` (retries courts).
+  Aucune action necessaire cote developpeur; ces protections sont en place pour la CI.
+


### PR DESCRIPTION
## Summary
- dispose explicitly the Alembic engine to release Windows SQLite file handles
- close test engines and retry unlink to avoid transient WinError 32
- document Windows SQLite file lock caveat in OPS guide

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/init_repo.ps1` *(fails: command not found)*
- `PYTHONPATH="backend" backend/.venv/bin/python -m pytest -q backend/tests/test_migrations.py`

Labels: tests, build, docs-required

------
https://chatgpt.com/codex/tasks/task_e_68ad76bd3e988330a0196ff084b88a21