### PR TITLE
Jalon 3 - Modeles metier (tables, migrations, tests). Relire docs/roadmap.md.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ REQUEST_ID_HEADER=X-Request-ID
 
 # Database (dev local; aucun secret en dur)
 
-DATABASE_URL=postgresql+psycopg://cc_user:cc_pass@localhost:5432/cc_dev
+# DATABASE_URL=sqlite:///./backend/dev.db  # optionnel en dev jalon 3 (sinon fallback)
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=cc_dev

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,3 +39,33 @@ PYTHONPATH=backend backend\.venv\Scripts\python -m pytest -q backend/tests/test_
 
 * Cible finale: Postgres 16 (avec Docker compose au Jalon 9). Au jalon 2, la CI s appuie sur SQLite pour des tests deterministes.
 * A partir du Jalon 3, les modeles metier seront introduits et les migrations evoluent.
+
+## Jalon 3 - Modeles metier
+
+### Enums
+
+* assignment_status: INVITED | ACCEPTED | DECLINED | CANCELLED
+* project_status: DRAFT | ACTIVE | ARCHIVED
+
+### Tables (principales)
+
+* orgs, accounts, users (+ skills, tags), projects, missions (+ roles), assignments, availability, invitations, audit_log.
+
+### Contraintes clefs
+
+* Unicite assignment actif par (mission_id, user_id): index unique partiel sur status IN ('INVITED','ACCEPTED')
+
+### Tests
+
+```powershell
+$Env:PYTHONPATH="backend"
+backend\.venv\Scripts\python -m pytest -q backend/tests/test_models_crud.py
+backend\.venv\Scripts\python -m pytest -q backend/tests/test_assignments_uniqueness.py
+```
+
+### Alembic
+
+```powershell
+$Env:DATABASE_URL="sqlite:///./backend/dev.db"
+backend\.venv\Scripts\alembic -c backend\alembic.ini upgrade head
+```

--- a/backend/alembic/versions/0002_models_core.py
+++ b/backend/alembic/versions/0002_models_core.py
@@ -1,0 +1,198 @@
+"""core models jalon 3
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers
+revision = "0002_models_core"
+down_revision = "0001_init_schema_meta"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "orgs",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False, unique=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+
+    op.create_table(
+        "accounts",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.String(length=36), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("email", sa.String(length=254), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("org_id", "email", name="uq_accounts_org_email"),
+    )
+    op.create_index("ix_accounts_email", "accounts", ["email"], unique=False)
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.String(length=36), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("account_id", sa.String(length=36), sa.ForeignKey("accounts.id", ondelete="SET NULL")),
+        sa.Column("first_name", sa.String(length=80), nullable=False),
+        sa.Column("last_name", sa.String(length=80), nullable=False),
+        sa.Column("employment_type", sa.String(length=20), nullable=False),
+        sa.Column("rate_profile", sa.JSON(), nullable=True),
+        sa.Column("legal_ids", sa.JSON(), nullable=True),
+        sa.Column("documents", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("org_id", "account_id", name="uq_users_org_account"),
+    )
+    op.create_index("ix_users_last_name", "users", ["last_name"], unique=False)
+    op.create_index("ix_users_first_name", "users", ["first_name"], unique=False)
+
+    op.create_table(
+        "projects",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.String(length=36), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.String(length=160), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default=sa.text("'DRAFT'")),
+        sa.Column("starts_at", sa.DateTime(), nullable=True),
+        sa.Column("ends_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("org_id", "name", name="uq_projects_org_name"),
+        sa.CheckConstraint("(ends_at IS NULL) OR (starts_at IS NULL) OR (ends_at >= starts_at)", name="ck_project_dates"),
+    )
+
+    op.create_table(
+        "missions",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.String(length=36), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("project_id", sa.String(length=36), sa.ForeignKey("projects.id", ondelete="SET NULL")),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("location", sa.String(length=200), nullable=True),
+        sa.Column("starts_at", sa.DateTime(), nullable=False),
+        sa.Column("ends_at", sa.DateTime(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("ends_at >= starts_at", name="ck_mission_dates"),
+    )
+    op.create_index("ix_missions_starts_at", "missions", ["starts_at"], unique=False)
+    op.create_index("ix_missions_ends_at", "missions", ["ends_at"], unique=False)
+    op.create_index("ix_missions_project_id", "missions", ["project_id"], unique=False)
+
+    op.create_table(
+        "mission_roles",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("mission_id", sa.String(length=36), sa.ForeignKey("missions.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("role_name", sa.String(length=80), nullable=False),
+        sa.Column("quota", sa.Integer(), nullable=False, server_default=sa.text("1")),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("mission_id", "role_name", name="uq_mission_role_name"),
+    )
+
+    op.create_table(
+        "assignments",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("mission_id", sa.String(length=36), sa.ForeignKey("missions.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("user_id", sa.String(length=36), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default=sa.text("'INVITED'")),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_assignments_mission_user", "assignments", ["mission_id", "user_id"], unique=False)
+    op.create_index(
+        "uq_active_assignment_per_mission_user",
+        "assignments",
+        ["mission_id", "user_id"],
+        unique=True,
+        sqlite_where=sa.text("status IN ('INVITED','ACCEPTED')"),
+        postgresql_where=sa.text("status IN ('INVITED','ACCEPTED')"),
+    )
+
+    op.create_table(
+        "availability",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.String(length=36), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("user_id", sa.String(length=36), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("starts_at", sa.DateTime(), nullable=False),
+        sa.Column("ends_at", sa.DateTime(), nullable=False),
+        sa.Column("note", sa.String(length=200), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("ends_at >= starts_at", name="ck_availability_dates"),
+    )
+    op.create_index("ix_availability_starts_at", "availability", ["starts_at"], unique=False)
+    op.create_index("ix_availability_ends_at", "availability", ["ends_at"], unique=False)
+
+    op.create_table(
+        "invitations",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.String(length=36), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("mission_id", sa.String(length=36), sa.ForeignKey("missions.id", ondelete="SET NULL")),
+        sa.Column("user_id", sa.String(length=36), sa.ForeignKey("users.id", ondelete="SET NULL")),
+        sa.Column("token", sa.String(length=64), nullable=False, unique=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.Column("revoked", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+
+    op.create_table(
+        "user_skills",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.String(length=36), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("skill", sa.String(length=80), nullable=False),
+        sa.Column("level", sa.Integer(), nullable=False, server_default=sa.text("1")),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("user_id", "skill", name="uq_user_skill"),
+    )
+
+    op.create_table(
+        "user_tags",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.String(length=36), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("tag", sa.String(length=50), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("user_id", "tag", name="uq_user_tag"),
+    )
+
+    op.create_table(
+        "audit_log",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.String(length=36), sa.ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("actor_account_id", sa.String(length=36), sa.ForeignKey("accounts.id", ondelete="SET NULL")),
+        sa.Column("action", sa.String(length=120), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audit_log")
+    op.drop_table("user_tags")
+    op.drop_table("user_skills")
+    op.drop_table("invitations")
+    op.drop_index("ix_availability_ends_at", table_name="availability")
+    op.drop_index("ix_availability_starts_at", table_name="availability")
+    op.drop_table("availability")
+    op.drop_index("uq_active_assignment_per_mission_user", table_name="assignments")
+    op.drop_index("ix_assignments_mission_user", table_name="assignments")
+    op.drop_table("assignments")
+    op.drop_table("mission_roles")
+    op.drop_index("ix_missions_project_id", table_name="missions")
+    op.drop_index("ix_missions_ends_at", table_name="missions")
+    op.drop_index("ix_missions_starts_at", table_name="missions")
+    op.drop_table("missions")
+    op.drop_table("projects")
+    op.drop_index("ix_users_first_name", table_name="users")
+    op.drop_index("ix_users_last_name", table_name="users")
+    op.drop_table("users")
+    op.drop_index("ix_accounts_email", table_name="accounts")
+    op.drop_table("accounts")
+    op.drop_table("orgs")

--- a/backend/app/enums.py
+++ b/backend/app/enums.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from enum import Enum
+
+
+class AssignmentStatus(str, Enum):
+    INVITED = "INVITED"
+    ACCEPTED = "ACCEPTED"
+    DECLINED = "DECLINED"
+    CANCELLED = "CANCELLED"
+
+
+class ProjectStatus(str, Enum):
+    DRAFT = "DRAFT"
+    ACTIVE = "ACTIVE"
+    ARCHIVED = "ARCHIVED"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .db import Base
+from .enums import AssignmentStatus, ProjectStatus
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class TSMixin:
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.utcnow(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.utcnow(), onupdate=lambda: datetime.utcnow(), nullable=False
+    )
+
+
+class Org(Base, TSMixin):
+    __tablename__ = "orgs"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    name: Mapped[str] = mapped_column(String(120), nullable=False, unique=True)
+
+
+class Account(Base, TSMixin):
+    __tablename__ = "accounts"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(String(36), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    email: Mapped[str] = mapped_column(String(254), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("org_id", "email", name="uq_accounts_org_email"),
+        Index("ix_accounts_email", "email"),
+    )
+
+
+class User(Base, TSMixin):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(String(36), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    account_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("accounts.id", ondelete="SET NULL"))
+    first_name: Mapped[str] = mapped_column(String(80), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(80), nullable=False)
+    employment_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    rate_profile: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    legal_ids: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    documents: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+
+    __table_args__ = (
+        Index("ix_users_last_name", "last_name"),
+        Index("ix_users_first_name", "first_name"),
+        UniqueConstraint("org_id", "account_id", name="uq_users_org_account", deferrable=False, initially=None),
+    )
+
+
+class UserSkill(Base, TSMixin):
+    __tablename__ = "user_skills"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    skill: Mapped[str] = mapped_column(String(80), nullable=False)
+    level: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+
+    __table_args__ = (UniqueConstraint("user_id", "skill", name="uq_user_skill"),)
+
+
+class UserTag(Base, TSMixin):
+    __tablename__ = "user_tags"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    tag: Mapped[str] = mapped_column(String(50), nullable=False)
+
+    __table_args__ = (UniqueConstraint("user_id", "tag", name="uq_user_tag"),)
+
+
+class Project(Base, TSMixin):
+    __tablename__ = "projects"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(String(36), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(160), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), default=ProjectStatus.DRAFT.value, nullable=False)
+    starts_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    ends_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("org_id", "name", name="uq_projects_org_name"),
+        CheckConstraint(
+            "(ends_at IS NULL) OR (starts_at IS NULL) OR (ends_at >= starts_at)",
+            name="ck_project_dates",
+        ),
+    )
+
+
+class Mission(Base, TSMixin):
+    __tablename__ = "missions"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(String(36), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    project_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("projects.id", ondelete="SET NULL"))
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    location: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    starts_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    ends_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint("ends_at >= starts_at", name="ck_mission_dates"),
+        Index("ix_missions_starts_at", "starts_at"),
+        Index("ix_missions_ends_at", "ends_at"),
+        Index("ix_missions_project_id", "project_id"),
+    )
+
+
+class MissionRole(Base, TSMixin):
+    __tablename__ = "mission_roles"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    mission_id: Mapped[str] = mapped_column(String(36), ForeignKey("missions.id", ondelete="CASCADE"), nullable=False)
+    role_name: Mapped[str] = mapped_column(String(80), nullable=False)
+    quota: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    __table_args__ = (UniqueConstraint("mission_id", "role_name", name="uq_mission_role_name"),)
+
+
+class Assignment(Base, TSMixin):
+    __tablename__ = "assignments"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    mission_id: Mapped[str] = mapped_column(String(36), ForeignKey("missions.id", ondelete="CASCADE"), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), default=AssignmentStatus.INVITED.value, nullable=False)
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("ix_assignments_mission_user", "mission_id", "user_id"),
+    )
+
+
+class Availability(Base, TSMixin):
+    __tablename__ = "availability"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(String(36), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    starts_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    ends_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    note: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint("ends_at >= starts_at", name="ck_availability_dates"),
+        Index("ix_availability_starts_at", "starts_at"),
+        Index("ix_availability_ends_at", "ends_at"),
+    )
+
+
+class Invitation(Base, TSMixin):
+    __tablename__ = "invitations"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(String(36), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    mission_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("missions.id", ondelete="SET NULL"))
+    user_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("users.id", ondelete="SET NULL"))
+    token: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    revoked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(String(36), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    actor_account_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("accounts.id", ondelete="SET NULL"))
+    action: Mapped[str] = mapped_column(String(120), nullable=False)
+    payload: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.utcnow(), nullable=False)

--- a/backend/tests/test_assignments_uniqueness.py
+++ b/backend/tests/test_assignments_uniqueness.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import gc
+import os
+import time
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+
+TEST_DB_PATH = Path("backend/test_unique.db").resolve()
+TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
+
+
+def _unlink_with_retry(p: Path, attempts: int = 10, delay_s: float = 0.1) -> None:
+    for _ in range(attempts):
+        try:
+            p.unlink(missing_ok=True)
+            return
+        except PermissionError:
+            gc.collect()
+            time.sleep(delay_s)
+    p.unlink(missing_ok=True)
+
+
+def setup_module(module) -> None:  # noqa: ANN001
+    if TEST_DB_PATH.exists():
+        _unlink_with_retry(TEST_DB_PATH)
+
+
+def teardown_module(module) -> None:  # noqa: ANN001
+    if TEST_DB_PATH.exists():
+        _unlink_with_retry(TEST_DB_PATH)
+
+
+def _alembic_upgrade(url: str) -> None:
+    os.environ["DB_URL"] = url
+    cfg = Config("backend/alembic.ini")
+    cfg.set_main_option("script_location", "backend/alembic")
+    command.upgrade(cfg, "head")
+
+
+def test_unique_active_assignment_ok_and_ko() -> None:
+    _alembic_upgrade(TEST_DB_URL)
+    eng = create_engine(TEST_DB_URL, future=True)
+    try:
+        with eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO orgs (id, name, created_at, updated_at) VALUES ('o1','Org',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO users (id, org_id, first_name, last_name, employment_type, created_at, updated_at) VALUES ('u1','o1','Sam','A','Intermittent',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO missions (id, org_id, title, starts_at, ends_at, created_at, updated_at) VALUES ('m1','o1','Balance','2024-01-01T10:00:00','2024-01-01T12:00:00',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                )
+            )
+
+            conn.execute(
+                text(
+                    "INSERT INTO assignments (id, mission_id, user_id, status, created_at, updated_at) VALUES ('a1','m1','u1','INVITED',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO assignments (id, mission_id, user_id, status, created_at, updated_at) VALUES ('a2','m1','u1','CANCELLED',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                )
+            )
+
+            try:
+                conn.execute(
+                    text(
+                        "INSERT INTO assignments (id, mission_id, user_id, status, created_at, updated_at) VALUES ('a3','m1','u1','ACCEPTED',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                    )
+                )
+                assert False, "Devrait violer l index unique partiel pour ACTIVE"
+            except Exception as e:
+                assert isinstance(e, IntegrityError) or "UNIQUE constraint failed" in str(e)
+    finally:
+        eng.dispose()

--- a/backend/tests/test_models_crud.py
+++ b/backend/tests/test_models_crud.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import gc
+import os
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+TEST_DB_PATH = Path("backend/test_models.db").resolve()
+TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
+
+
+def _unlink_with_retry(p: Path, attempts: int = 10, delay_s: float = 0.1) -> None:
+    for _ in range(attempts):
+        try:
+            p.unlink(missing_ok=True)
+            return
+        except PermissionError:
+            gc.collect()
+            time.sleep(delay_s)
+    p.unlink(missing_ok=True)
+
+
+def setup_module(module) -> None:  # noqa: ANN001
+    if TEST_DB_PATH.exists():
+        _unlink_with_retry(TEST_DB_PATH)
+
+
+def teardown_module(module) -> None:  # noqa: ANN001
+    if TEST_DB_PATH.exists():
+        _unlink_with_retry(TEST_DB_PATH)
+
+
+def _alembic_upgrade(url: str) -> None:
+    os.environ["DB_URL"] = url
+    cfg = Config("backend/alembic.ini")
+    cfg.set_main_option("script_location", "backend/alembic")
+    command.upgrade(cfg, "head")
+
+
+def test_crud_minimal_flow() -> None:
+    _alembic_upgrade(TEST_DB_URL)
+    engine = create_engine(TEST_DB_URL, future=True)
+    from app.enums import AssignmentStatus, ProjectStatus  # import after upgrade
+    _ = (AssignmentStatus, ProjectStatus)
+
+    with Session(engine, future=True) as s:
+        # Org
+        s.execute(
+            text(
+                "INSERT INTO orgs (id, name, created_at, updated_at) VALUES ('org1','Org A',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        # Account
+        s.execute(
+            text(
+                "INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at) VALUES ('acc1','org1','a@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        # User
+        s.execute(
+            text(
+                "INSERT INTO users (id, org_id, account_id, first_name, last_name, employment_type, created_at, updated_at) VALUES ('u1','org1','acc1','Sam','A','Intermittent',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        # Project
+        s.execute(
+            text(
+                "INSERT INTO projects (id, org_id, name, status, created_at, updated_at) VALUES ('p1','org1','Projet X','DRAFT',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        # Mission
+        now = datetime.utcnow()
+        later = now + timedelta(hours=2)
+        s.execute(
+            text(
+                "INSERT INTO missions (id, org_id, project_id, title, starts_at, ends_at, created_at, updated_at) VALUES ('m1','org1','p1','Balance','%s','%s',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                % (now.isoformat(), later.isoformat())
+            )
+        )
+        # Role
+        s.execute(
+            text(
+                "INSERT INTO mission_roles (id, mission_id, role_name, quota, created_at, updated_at) VALUES ('mr1','m1','Regie','1',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        # Assignment INVITED
+        s.execute(
+            text(
+                "INSERT INTO assignments (id, mission_id, user_id, status, created_at, updated_at) VALUES ('a1','m1','u1','INVITED',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        # Availability
+        s.execute(
+            text(
+                "INSERT INTO availability (id, org_id, user_id, starts_at, ends_at, created_at, updated_at) VALUES ('av1','org1','u1','%s','%s',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                % (now.isoformat(), later.isoformat())
+            )
+        )
+        # Invitation
+        s.execute(
+            text(
+                "INSERT INTO invitations (id, org_id, mission_id, user_id, token, revoked, created_at, updated_at) VALUES ('i1','org1','m1','u1','tok123',0,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+
+        res = s.execute(text("SELECT COUNT(*) FROM assignments")).scalar_one()
+        assert res == 1
+        res = s.execute(text("SELECT status FROM assignments WHERE id='a1'")).scalar_one()
+        assert res == "INVITED"
+
+    engine.dispose()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,1 +1,24 @@
-Jalon 0: monorepo BE/FE minimal, middleware request_id, logs JSON, smoke ping.
+# Architecture (extrait jalon 3)
+
+## ERD ASCII (simplifie)
+
+orgs (id) 1--* accounts
+orgs (id) 1--* users
+orgs (id) 1--* projects 1--* missions 1--* mission_roles
+missions (id) 1--* assignments *--1 users
+users (id) 1--* user_skills
+users (id) 1--* user_tags
+users (id) 1--* availability
+missions (id) 1--* invitations (optionnel user_id)
+orgs (id) 1--* audit_log
+
+## Enums
+
+* assignment_status: INVITED, ACCEPTED, DECLINED, CANCELLED
+* project_status: DRAFT, ACTIVE, ARCHIVED
+
+## Indexes
+
+* users: ix_users_last_name, ix_users_first_name
+* missions: ix_missions_starts_at, ix_missions_ends_at
+* assignments: uq_active_assignment_per_mission_user (unique partiel status ACTIVE)


### PR DESCRIPTION
## Summary
- add enums and SQLAlchemy models for core multi-tenant entities
- create Alembic migration for new tables and indexes
- document ERD, enums and constraints in backend README and ARCHITECTURE

## Testing
- `ruff check backend`
- `PYTHONPATH=backend mypy backend`
- `PYTHONPATH=backend pytest -q backend/tests/test_models_crud.py`
- `PYTHONPATH=backend pytest -q backend/tests/test_assignments_uniqueness.py`

Please re-read docs/ROADMAP.md; propose updates if any divergence is found.

------
https://chatgpt.com/codex/tasks/task_e_68ad79e6d6688330ba9fa6250cb8cd91