### PR TITLE
Fix CI backend: installer ruff/mypy/pytest via requirements-dev. Relire docs/roadmap.md.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           python -m pip install -U pip
           python -m venv backend/.venv
           backend/.venv/Scripts/pip install -r backend/requirements.txt
+          if exist backend\requirements-dev.txt backend\.venv\Scripts\pip install -r backend\requirements-dev.txt
       - name: Lints
         run: |
           backend/.venv/Scripts/python -m ruff check backend

--- a/PS1/init_repo.ps1
+++ b/PS1/init_repo.ps1
@@ -7,12 +7,10 @@ Write-Host "[init_repo] Preparation du repo..." -ForegroundColor Cyan
 # Ensurer encodage UTF8
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
-# Verifs prerequis
-
 function Require-Cmd($name) {
-    if (-not (Get-Command $name -ErrorAction SilentlyContinue)) {
-        Write-Error "Outil requis manquant: $name" ; exit 2
-    }
+if (-not (Get-Command $name -ErrorAction SilentlyContinue)) {
+Write-Error "Outil requis manquant: $name" ; exit 2
+}
 }
 Require-Cmd "python"
 Require-Cmd "npm"
@@ -21,12 +19,21 @@ Require-Cmd "npm"
 
 $venv = Join-Path -Path "backend" -ChildPath ".venv"
 if (-not (Test-Path $venv)) {
-    Write-Host "[init_repo] Creation venv..." -ForegroundColor Cyan
-    python -m venv $venv
+Write-Host "[init_repo] Creation venv..." -ForegroundColor Cyan
+python -m venv $venv
 }
 & (Join-Path $venv "Scripts\pip.exe") install -U pip
-# Installe dependances backend (incluant SQLAlchemy + Alembic)
+
+# Installe runtime
+
 & (Join-Path $venv "Scripts\pip.exe") install -r (Join-Path "backend" "requirements.txt")
+
+# Installe dev si le fichier existe
+
+$reqDev = Join-Path "backend" "requirements-dev.txt"
+if (Test-Path $reqDev) {
+& (Join-Path $venv "Scripts\pip.exe") install -r $reqDev
+}
 
 # Frontend install
 

--- a/README.md
+++ b/README.md
@@ -40,16 +40,32 @@ Tout changement de CLI/API/env/scripts/ports/procedures => MAJ README(s) concern
 
 ## Dependances et lockfiles
 
-Les lockfiles sont obligatoires (policy DEPENDANCES). Pour le frontend:
+Les lockfiles sont obligatoires (policy DEPENDANCES).
+
+### Backend
+
+* Runtime: `backend/requirements.txt`
+* Dev (CI lints/tests): `backend/requirements-dev.txt`
 
 ```powershell
-# Regenerer le lockfile apres modification de package.json
+# Installation locale (incluant outils dev)
+pwsh -NoLogo -NoProfile -File PS1/init_repo.ps1
+# ou manuellement:
+python -m venv backend/.venv
+backend\.venv\Scripts\pip install -r backend\requirements.txt -r backend\requirements-dev.txt
+```
+
+### Frontend
+
+* `frontend/package-lock.json` doit etre committe.
+
+```powershell
 pwsh -NoLogo -NoProfile -File PS1/gen_frontend_lock.ps1
 git add frontend/package-lock.json
 git commit -m "chore(frontend): regen package-lock"
 ```
 
-La CI utilise `npm ci` et echouera si `frontend/package-lock.json` est absent ou non committe.
+La CI utilise `npm ci` et echouera si le lockfile est absent.
 
 ## FAQ
 

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Outils de dev CI/lints/tests (versions epinglees)
+
+ruff==0.6.8
+mypy==1.10.0
+pytest==8.2.0
+pytest-cov==5.0.0


### PR DESCRIPTION
## Summary
- add pinned backend/requirements-dev.txt for CI tools
- install dev deps in init_repo.ps1 and CI workflow
- document runtime vs dev deps in README

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/init_repo.ps1`
- `backend/.venv/Scripts/python -m ruff --version`
- `backend/.venv/Scripts/python -m mypy --version`
- `PYTHONPATH=backend backend/.venv/Scripts/python -m pytest -q` *(fails: ModuleNotFoundError: email_validator)*

------
https://chatgpt.com/codex/tasks/task_e_68ad843b216483308df65360dc20cb03