### PR TITLE
Fix CI backend: syntaxe PowerShell dans workflow + ajout email-validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,23 @@ jobs:
       - uses: actions/setup-python@v5
         with: { python-version: "3.10" }
       - name: Backend deps
+        shell: pwsh
         run: |
           python -m pip install -U pip
           python -m venv backend/.venv
-          backend/.venv/Scripts/pip install -r backend/requirements.txt
-          if exist backend\requirements-dev.txt backend\.venv\Scripts\pip install -r backend\requirements-dev.txt
+          backend\.venv\Scripts\pip install -r backend\requirements.txt
+          if (Test-Path "backend\requirements-dev.txt") { backend\.venv\Scripts\pip install -r backend\requirements-dev.txt }
       - name: Lints
+        shell: pwsh
         run: |
-          backend/.venv/Scripts/python -m ruff check backend
-          backend/.venv/Scripts/python -m mypy backend
+          backend\.venv\Scripts\python -m ruff check backend
+          backend\.venv\Scripts\python -m mypy backend
       - name: Tests
+        shell: pwsh
         env:
           PYTHONPATH: backend
         run: |
-          backend/.venv/Scripts/python -m pytest -q --disable-warnings --maxfail=1
+          backend\.venv\Scripts\python -m pytest -q --disable-warnings --maxfail=1
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Les lockfiles sont obligatoires (policy DEPENDANCES).
 
 ### Backend
 
-* Runtime: `backend/requirements.txt`
+* Runtime: `backend/requirements.txt` (inclut `email-validator` requis par `pydantic.EmailStr`)
 * Dev (CI lints/tests): `backend/requirements-dev.txt`
 
 ```powershell

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,7 @@ alembic==1.13.2
 PyJWT==2.9.0
 passlib==1.7.4
 bcrypt==4.2.0
+
+# Pydantic EmailStr support
+
+email-validator==2.1.1


### PR DESCRIPTION
## Summary
- fix Windows CI by using PowerShell `Test-Path` instead of `if exist`
- add `email-validator` runtime dependency for `pydantic.EmailStr`
- document `email-validator` requirement in README

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/init_repo.ps1` *(fails: command not found)*
- `backend/.venv/bin/pip install -r backend/requirements.txt -r backend/requirements-dev.txt`
- `backend/.venv/bin/python -m ruff --version`
- `backend/.venv/bin/python -m mypy --version`
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest -q` *(fails: OperationalError: no such table: orgs)*
- `pwsh -NoLogo -NoProfile -File tools/docs_guard.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File tools/readme_check.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8664a1fc8330a2bd9a1f37068c4b