### PR TITLE
Fix CI backend: E402 dans tests, mypy passlib/typing, degrade scripts .sh. Relire docs/roadmap.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ pwsh -NoLogo -NoProfile -File PS1/dev_up.ps1
 * tools/docs_guard.ps1 : guard doc
 * tools/readme_check.ps1 : verif sections README
 
+### Outils docs (Windows-first)
+
+* PowerShell: `tools/docs_guard.ps1`, `tools/readme_check.ps1`
+* Degrade Linux/macOS: `tools/docs_guard.sh`, `tools/readme_check.sh` (optionnels hors CI)
+
 ## Envs requis
 
 Voir .env.example. Pas de secrets dans le repo.

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+python_version = 3.10
+warn_unused_ignores = True
+warn_redundant_casts = True
+
+[mypy-passlib.*]
+ignore_missing_imports = True
+
+[mypy-jwt.*]
+ignore_missing_imports = True

--- a/backend/tests/test_auth_flow.py
+++ b/backend/tests/test_auth_flow.py
@@ -1,35 +1,22 @@
 from __future__ import annotations
 import os
-os.environ["ENV"] = "dev"
 from pathlib import Path
-
-TEST_DB_PATH = Path("backend/test_auth.db").resolve()
-TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
-os.environ["DATABASE_URL"] = TEST_DB_URL
 
 from alembic import command
 from alembic.config import Config
 from fastapi.testclient import TestClient
-from app.main import create_app
 from sqlalchemy import create_engine, text
 
-from app.auth import hash_password
-
-
-def _upgrade(url: str) -> None:
-    os.environ["DB_URL"] = url
-    os.environ["DATABASE_URL"] = url
-    cfg = Config("backend/alembic.ini")
-    command.upgrade(cfg, "head")
-
+TEST_DB_PATH = Path("backend/test_auth.db").resolve()
+TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
 
 def _cleanup() -> None:
     if TEST_DB_PATH.exists():
         try:
             TEST_DB_PATH.unlink(missing_ok=True)
         except PermissionError:
+            # Runner Windows: verrou residuel, ignorer
             pass
-
 
 def setup_module(module) -> None:  # noqa: ANN001
     _cleanup()
@@ -38,18 +25,31 @@ def setup_module(module) -> None:  # noqa: ANN001
 def teardown_module(module) -> None:  # noqa: ANN001
     _cleanup()
 
+def _upgrade(url: str) -> None:
+    os.environ["DB_URL"] = url
+    cfg = Config("backend/alembic.ini")
+    command.upgrade(cfg, "head")
+
 
 def test_login_refresh_me_logout_flow() -> None:
+    # Config env AVANT import de l app (engine DB lit DATABASE_URL a l import)
+    os.environ["ENV"] = "dev"
+    os.environ["DATABASE_URL"] = TEST_DB_URL
+
     _upgrade(TEST_DB_URL)
-    client = TestClient(create_app())
+
+    # Import tardif pour respecter E402 et prendre la bonne DB
+    from app.main import create_app
+    from app.auth import hash_password
+
+    app = create_app()
+    client = TestClient(app)
 
     eng = create_engine(TEST_DB_URL, future=True)
     with eng.begin() as conn:
         conn.execute(text("INSERT INTO orgs (id, name, created_at, updated_at) VALUES ('o1','Org',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"))
         conn.execute(
-            text(
-                "INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at, password_hash) VALUES ('a1','o1','sam@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,:ph)"
-            ),
+            text("INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at, password_hash) VALUES ('a1','o1','sam@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,:ph)"),
             {"ph": hash_password("secret")},
         )
 
@@ -65,12 +65,12 @@ def test_login_refresh_me_logout_flow() -> None:
     assert r2.status_code == 200
     assert r2.json()["email"] == "sam@example.com"
 
-    # refresh to get new access
+    # refresh to get new access (lit le cookie)
     r3 = client.post("/api/v1/auth/refresh")
     assert r3.status_code == 200
     assert r3.json().get("access_token")
 
-    # logout clears cookie
+    # logout
     r4 = client.post("/api/v1/auth/logout")
     assert r4.status_code == 200
     assert r4.json()["status"] == "ok"

--- a/backend/tests/test_password_reset_flow.py
+++ b/backend/tests/test_password_reset_flow.py
@@ -1,27 +1,14 @@
 from __future__ import annotations
 import os
-os.environ["ENV"] = "dev"
 from pathlib import Path
-
-TEST_DB_PATH = Path("backend/test_reset.db").resolve()
-TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
-os.environ["DATABASE_URL"] = TEST_DB_URL
 
 from alembic import command
 from alembic.config import Config
 from fastapi.testclient import TestClient
-from app.main import create_app
 from sqlalchemy import create_engine, text
 
-from app.auth import verify_password
-
-
-def _upgrade(url: str) -> None:
-    os.environ["DB_URL"] = url
-    os.environ["DATABASE_URL"] = url
-    cfg = Config("backend/alembic.ini")
-    command.upgrade(cfg, "head")
-
+TEST_DB_PATH = Path("backend/test_reset.db").resolve()
+TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
 
 def _cleanup() -> None:
     if TEST_DB_PATH.exists():
@@ -30,38 +17,47 @@ def _cleanup() -> None:
         except PermissionError:
             pass
 
-
 def setup_module(module) -> None:  # noqa: ANN001
     _cleanup()
-
 
 def teardown_module(module) -> None:  # noqa: ANN001
     _cleanup()
 
+def _upgrade(url: str) -> None:
+    os.environ["DB_URL"] = url
+    cfg = Config("backend/alembic.ini")
+    command.upgrade(cfg, "head")
 
 def test_password_reset_dev_flow() -> None:
+    os.environ["ENV"] = "dev"
+    os.environ["DATABASE_URL"] = TEST_DB_URL
+
     _upgrade(TEST_DB_URL)
-    client = TestClient(create_app())
+
+    # Import tardif pour E402 + bonne DB
+    from app.main import create_app
+    from app.auth import verify_password
+
+    app = create_app()
+    client = TestClient(app)
 
     eng = create_engine(TEST_DB_URL, future=True)
     with eng.begin() as conn:
         conn.execute(text("INSERT INTO orgs (id, name, created_at, updated_at) VALUES ('o1','Org',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"))
-        conn.execute(
-            text("INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at, password_hash) VALUES ('a1','o1','user@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,'$2b$12$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')")
-        )
+        conn.execute(text("INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at, password_hash) VALUES ('a1','o1','user@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,'$2b$12$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')"))
 
-    # request reset (in dev returns token)
+    # request reset (en dev renvoie le token)
     r = client.post("/api/v1/auth/reset/request", json={"email": "user@example.com"})
     assert r.status_code == 200
     tok = r.json().get("reset_token")
-    assert tok, "en dev, le token doit etre renvoye"
+    assert tok
 
     # confirm reset
     r2 = client.post("/api/v1/auth/reset/confirm", json={"token": tok, "new_password": "newpass123"})
     assert r2.status_code == 200
 
-    # verify password actually changed
+    # verifier MAJ du hash
     with eng.connect() as conn:
-        ph = conn.execute(text("SELECT password_hash FROM accounts WHERE email='user@example.com'"))
-        ph = ph.scalar_one()
+        val = conn.execute(text("SELECT password_hash FROM accounts WHERE email='user@example.com'")).scalar_one()
+        ph: str = str(val)
         assert verify_password("newpass123", ph)

--- a/tools/docs_guard.sh
+++ b/tools/docs_guard.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+changed=$(git diff --name-only HEAD~~1 2>/dev/null | grep -E '^(backend|frontend|PS1|tools|.github)' || true)
+if [[ -n "${changed}" ]]; then
+    docs_changed=$(git diff --name-only HEAD~~1 2>/dev/null | grep -E '^(README.md|docs/)' || true)
+    if [[ -z "${docs_changed}" ]]; then
+        echo "Docs guard: changements code sans mise a jour README/docs." >&2
+        exit 1
+    fi
+fi
+echo "Docs guard OK"

--- a/tools/readme_check.sh
+++ b/tools/readme_check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+content="$(cat README.md 2>/dev/null || true)"
+missing=0
+for s in "Quickstart Windows" "Scripts clefs" "Envs requis" "Ports" "Tests/Lint" "FAQ" "Badges" "README Policy" "Dependances et lockfiles"; do
+    if ! grep -qF "$s" <<<"$content"; then
+        echo "README incomplet: section manquante: $s" >&2
+        missing=1
+    fi
+done
+[[ $missing -eq 0 ]] && echo "README structure OK" || exit 1


### PR DESCRIPTION
## Summary
- fix imports in auth tests and delay app load
- ignore passlib/jwt missing stubs
- add bash docs guard and readme structure check

## Testing
- `backend/.venv/bin/python -m ruff check backend`
- `backend/.venv/bin/python -m mypy --config-file backend/mypy.ini backend`
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest -q` *(fails: no such table: accounts)*
- `bash tools/docs_guard.sh && bash tools/readme_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ad88b0935c8330afb203f0b23d699d