### PR TITLE
Fix CI backend: mypy passlib (ignore import-untyped) + mypy --config-file + doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         shell: pwsh
         run: |
           backend\.venv\Scripts\python -m ruff check backend
-          backend\.venv\Scripts\python -m mypy backend
+          backend\.venv\Scripts\python -m mypy --config-file backend\mypy.ini backend
       - name: Tests
         shell: pwsh
         env:

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -8,7 +8,7 @@ $venv = Join-Path "backend" ".venv"
 $py = Join-Path $venv "Scripts\python.exe"
 
 & $py -m ruff check backend
-& $py -m mypy backend
+& $py -m mypy --config-file backend\mypy.ini backend
 
 # Ensure PYTHONPATH=backend for app imports
 $Env:PYTHONPATH = "backend"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ BE 8000 ; FE 5173 ; DB 5432 ; Redis 6379 ; Adminer 8080.
 pwsh -NoLogo -NoProfile -File PS1/test_all.ps1
 ```
 
+### Typing (passlib)
+
+passlib n a pas de stubs types officiels; nous ignorons l import via `# type: ignore[import-untyped]` dans `backend/app/auth.py`. La CI appelle mypy avec `--config-file backend/mypy.ini`.
+
 ## README Policy
 
 Tout changement de CLI/API/env/scripts/ports/procedures => MAJ README(s) concernes (root + dossiers). CI docs guard echoue si non mis a jour.

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 import jwt
-from passlib.context import CryptContext
+from passlib.context import CryptContext  # type: ignore[import-untyped, unused-ignore]
 from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session


### PR DESCRIPTION
## Summary
- ignore passlib import-untyped warning in auth
- run mypy with explicit backend config
- document passlib typing workaround

## Testing
- `backend/.venv/bin/python -m ruff check backend`
- `backend/.venv/bin/python -m mypy --config-file backend/mypy.ini backend`
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest -q` *(fails: no such table: accounts)*
- `./tools/docs_guard.sh`
- `./tools/readme_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ad8e50e4e8833082005a0e8e7ef795