### PR TITLE
Fix CI backend: mypy passlib (ignore inline + disable_error_code module-scoped)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ pwsh -NoLogo -NoProfile -File PS1/test_all.ps1
 
 ### Typing (passlib)
 
-passlib n a pas de stubs types officiels; nous ignorons l import via `# type: ignore[import-untyped]` dans `backend/app/auth.py`. La CI appelle mypy avec `--config-file backend/mypy.ini`.
+passlib n a pas de stubs officiels. Nous:
+
+* ignorons l import dans `backend/app/auth.py` via `# type: ignore[import-untyped]`
+* desactivons `import-untyped` uniquement pour `passlib.*` dans `backend/mypy.ini`
 
 ## README Policy
 

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -5,6 +5,7 @@ warn_redundant_casts = True
 
 [mypy-passlib.*]
 ignore_missing_imports = True
+disable_error_code = import-untyped
 
 [mypy-jwt.*]
 ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- silence passlib import-untyped via inline ignore
- disable mypy import-untyped errors for passlib modules
- document passlib typing strategy in README

## Testing
- `backend/.venv/bin/python -m ruff check backend`
- `backend/.venv/bin/python -m mypy --config-file backend/mypy.ini backend`
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest -q` *(fails: no such table: accounts)*

------
https://chatgpt.com/codex/tasks/task_e_68ad93188e088330b4f4d6e2a3d64452