### PR TITLE
Fix Jalon 4: rebind DB a l app factory pour eliminer 'no such table: accounts' en tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -97,3 +97,21 @@ $Env:PYTHONPATH="backend"
 backend\.venv\Scripts\python -m pytest -q backend/tests/test_auth_flow.py
 backend\.venv\Scripts\python -m pytest -q backend/tests/test_password_reset_flow.py
 ```
+
+### Note DB pour les tests (robustesse ordre d import)
+
+L app utilise une **factory** `create_app()` qui rebinde l engine/Session sur `DATABASE_URL` courant via `set_database_url()` (dans `app.db`).
+Cela evite les erreurs type `no such table: accounts` quand un autre test importe l app avant d avoir positionne `DATABASE_URL`.
+
+### Tests
+
+```powershell
+$Env:PYTHONPATH="backend"
+backend\.venv\Scripts\python -m pytest -q
+```
+
+ou
+
+```bash
+PYTHONPATH=backend backend/.venv/bin/python -m pytest -q
+```

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -6,20 +6,31 @@ from typing import Generator
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, DeclarativeBase
 
-# DATABASE_URL prioritaire, fallback SQLite fichier pour CI jalon 2
+# DATABASE_URL prioritaire, fallback SQLite fichier pour CI
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./backend/dev.db")
 
 class Base(DeclarativeBase):
     pass
 
-engine = create_engine(
-    DATABASE_URL,
-    echo=False,
-    future=True,
-)
-
+engine = create_engine(DATABASE_URL, echo=False, future=True)
+# Engine + SessionLocal initiaux (seront reconfigures via set_database_url en tests/app factory)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def set_database_url(url: str) -> None:
+    """
+    Reconfigure l engine/SessionLocal sur une nouvelle URL (utile pour tests).
+    Idempotent; ferme l ancien engine si present.
+    """
+    global engine, SessionLocal, DATABASE_URL
+    DATABASE_URL = url
+    try:
+        engine.dispose()
+    except Exception:
+        pass
+    engine = create_engine(url, echo=False, future=True)
+    SessionLocal.configure(bind=engine)
 
 @contextmanager
 def session_scope() -> Generator:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,20 @@
+from __future__ import annotations
+import os
+import uuid
 from fastapi import FastAPI, Request
 from .settings import settings
 from .logging_conf import setup as setup_logging
 from .api import router as api_router
 from .api_auth import router as auth_router
-import uuid
+from .db import set_database_url
 
 def create_app() -> FastAPI:
     setup_logging()
+    # Rebind DB a chaque creation d app (prend en compte DATABASE_URL courant)
+    url = os.getenv("DATABASE_URL", "sqlite:///./backend/dev.db")
+    set_database_url(url)
+    os.environ.pop("DATABASE_URL", None)
+
     app = FastAPI(title=settings.app_name)
 
     @app.middleware("http")
@@ -17,9 +25,14 @@ def create_app() -> FastAPI:
         response.headers[settings.request_id_header] = rid
         return response
 
+    @app.get("/healthz")
+    def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
     app.include_router(api_router)
     app.include_router(auth_router)
     return app
 
 
+# Instance module-level pour /healthz etc. (tests auth utilisent create_app())
 app = create_app()


### PR DESCRIPTION
## Summary
- reconfigure engine via new `set_database_url()` and reuse in tests
- rebind DB inside `create_app()` and expose `/healthz`
- document test DB rebinding and commands

## Testing
- `PYTHONPATH=backend backend/.venv/bin/ruff check backend/app/main.py backend/app/db.py`
- `PYTHONPATH=backend backend/.venv/bin/mypy backend/app/db.py backend/app/main.py`
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9750f2548330bd041e05aeca8720