### PR TITLE
Jalon 5 - RBAC et multi-tenant (org_memberships + deps + tests)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -115,3 +115,24 @@ ou
 ```bash
 PYTHONPATH=backend backend/.venv/bin/python -m pytest -q
 ```
+
+## RBAC (Jalon 5)
+
+* Table `org_memberships`: (id, org_id, account_id, role: owner|admin|manager|tech)
+* Enforcement:
+  * `require_role(min_role)` -> verifie qu'un account est membre de l'org du token et que son role >= min_role
+  * `require_org_scope(org_id)` -> verifie que l'org_id du path == claim `org`
+* Endpoints de demo (pour tests):
+  * GET `/api/v1/rbac_demo/any` (membre requis)
+  * GET `/api/v1/rbac_demo/manager` (>= manager)
+  * GET `/api/v1/rbac_demo/admin` (>= admin)
+  * GET `/api/v1/rbac_demo/owner` (== owner)
+  * GET `/api/v1/rbac_demo/scoped/{org_id}` (scope org strict)
+* Tests:
+
+```powershell
+$Env:PYTHONPATH="backend"
+backend\.venv\Scripts\python -m pytest -q -k "rbac"
+```
+
+* Matrice roles x actions minimale: owner > admin > manager > tech. Les endpoints metier (Jalon 6) utiliseront ces deps pour le controle fin. (Roadmap Jalon 5-6).

--- a/backend/alembic/versions/0004_rbac_org_memberships.py
+++ b/backend/alembic/versions/0004_rbac_org_memberships.py
@@ -1,0 +1,44 @@
+"""RBAC Jalon 5: add org_memberships (account<->org with role)
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0004_rbac_org_memberships"
+down_revision = "0003_auth_password_reset"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_memberships",
+        sa.Column("id", sa.String(length=64), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.String(length=64), nullable=False),
+        sa.Column("account_id", sa.String(length=64), nullable=False),
+        sa.Column("role", sa.String(length=16), nullable=False),  # owner|admin|manager|tech
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(
+        "ix_org_memberships_org_acc",
+        "org_memberships",
+        ["org_id", "account_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_org_memberships_org_acc", table_name="org_memberships")
+    op.drop_table("org_memberships")

--- a/backend/app/api_rbac_demo.py
+++ b/backend/app/api_rbac_demo.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from .rbac import Role, require_org_scope, require_role
+
+router = APIRouter(prefix="/api/v1/rbac_demo", tags=["rbac-demo"])
+
+
+@router.get("/any")
+def any_member(_ctx=Depends(require_role(Role.tech))) -> dict[str, bool | str]:
+    return {"ok": True, "need": "tech"}
+
+
+@router.get("/manager")
+def only_manager_plus(_ctx=Depends(require_role(Role.manager))) -> dict[str, bool | str]:
+    return {"ok": True, "need": "manager+"}
+
+
+@router.get("/admin")
+def only_admin_plus(_ctx=Depends(require_role(Role.admin))) -> dict[str, bool | str]:
+    return {"ok": True, "need": "admin+"}
+
+
+@router.get("/owner")
+def only_owner(_ctx=Depends(require_role(Role.owner))) -> dict[str, bool | str]:
+    return {"ok": True, "need": "owner"}
+
+
+@router.get("/scoped/{org_id}")
+def scoped(_=Depends(require_org_scope)) -> dict[str, bool | str]:
+    return {"ok": True, "scope": "org"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from .settings import settings
 from .logging_conf import setup as setup_logging
 from .api import router as api_router
 from .api_auth import router as auth_router
+from .api_rbac_demo import router as rbac_demo_router
 from .db import set_database_url
 
 def create_app() -> FastAPI:
@@ -31,6 +32,7 @@ def create_app() -> FastAPI:
 
     app.include_router(api_router)
     app.include_router(auth_router)
+    app.include_router(rbac_demo_router)
     return app
 
 

--- a/backend/app/rbac.py
+++ b/backend/app/rbac.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Any, Callable, Dict
+
+from fastapi import Depends, HTTPException, Path, status
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from .auth import get_current_account, get_db
+
+
+class Role(IntEnum):
+    tech = 10
+    manager = 20
+    admin = 30
+    owner = 40
+
+
+def _role_score(role_str: str) -> int:
+    try:
+        return Role[role_str].value
+    except KeyError:
+        return -1
+
+
+def require_role(min_role: Role) -> Callable:
+    """
+    Dep FastAPI: exige membership dans l'org et un rôle >= min_role
+    """
+
+    def dep(
+        current: Dict[str, Any] = Depends(get_current_account),
+        db: Session = Depends(get_db),
+    ) -> Dict[str, Any]:
+        org_id = current["org_id"]
+        acc_id = current["id"]
+        row = db.execute(
+            text(
+                "SELECT role FROM org_memberships WHERE org_id=:o AND account_id=:a"
+            ),
+            {"o": org_id, "a": acc_id},
+        ).fetchone()
+        if not row:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="membre requis"
+            )
+        if _role_score(str(row.role)) < int(min_role):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="role insuffisant"
+            )
+        return {"org_id": org_id, "account_id": acc_id, "role": row.role}
+
+    return dep
+
+
+def require_org_scope(
+    org_id: str = Path(...),
+    current: Dict[str, Any] = Depends(get_current_account),
+) -> Dict[str, Any]:
+    """Dep: exige que l'org_id du path corresponde au claim org du token"""
+    if current["org_id"] != org_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="org mismatch"
+        )
+    return {"org_id": org_id, "account_id": current["id"]}

--- a/backend/tests/test_rbac.py
+++ b/backend/tests/test_rbac.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+TEST_DB_PATH = Path("backend/test_rbac.db").resolve()
+TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
+
+
+def _cleanup() -> None:
+    if TEST_DB_PATH.exists():
+        try:
+            TEST_DB_PATH.unlink(missing_ok=True)
+        except PermissionError:
+            pass
+
+
+def setup_module(module) -> None:  # noqa: ANN001
+    _cleanup()
+
+
+def teardown_module(module) -> None:  # noqa: ANN001
+    _cleanup()
+
+
+def _upgrade(url: str) -> None:
+    os.environ["DB_URL"] = url
+    os.environ["DATABASE_URL"] = url
+    cfg = Config("backend/alembic.ini")
+    command.upgrade(cfg, "head")
+
+
+def _mk_token(account_id: str, org_id: str) -> str:
+    # import tardif apres alembic
+    from app.auth import create_access_token
+
+    return create_access_token(account_id, org_id)
+
+
+def _client() -> TestClient:
+    from app.main import create_app
+
+    app = create_app()
+    return TestClient(app)
+
+
+def test_rbac_enforcement_ok_and_ko() -> None:
+    os.environ["ENV"] = "dev"
+    _upgrade(TEST_DB_URL)
+
+    eng = create_engine(TEST_DB_URL, future=True)
+    with eng.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO orgs (id, name, created_at, updated_at) "
+                "VALUES ('o1','Org1',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO orgs (id, name, created_at, updated_at) "
+                "VALUES ('o2','Org2',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at) "
+                "VALUES ('a1','o1','a1@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at) "
+                "VALUES ('a2','o1','a2@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO org_memberships (id, org_id, account_id, role, created_at, updated_at) "
+                "VALUES ('m1','o1','a1','manager',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO org_memberships (id, org_id, account_id, role, created_at, updated_at) "
+                "VALUES ('m2','o1','a2','tech',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+
+    t_mgr = _mk_token("a1", "o1")
+    t_tech = _mk_token("a2", "o1")
+
+    client = _client()
+
+    # any: membre requis
+    r = client.get(
+        "/api/v1/rbac_demo/any", headers={"Authorization": f"Bearer {t_mgr}"}
+    )
+    assert r.status_code == 200
+    r = client.get(
+        "/api/v1/rbac_demo/any", headers={"Authorization": f"Bearer {t_tech}"}
+    )
+    assert r.status_code == 200
+
+    # manager+: tech doit echouer
+    r = client.get(
+        "/api/v1/rbac_demo/manager",
+        headers={"Authorization": f"Bearer {t_mgr}"},
+    )
+    assert r.status_code == 200
+    r = client.get(
+        "/api/v1/rbac_demo/manager",
+        headers={"Authorization": f"Bearer {t_tech}"},
+    )
+    assert r.status_code == 403
+
+    # admin+: manager echoue
+    r = client.get(
+        "/api/v1/rbac_demo/admin", headers={"Authorization": f"Bearer {t_mgr}"}
+    )
+    assert r.status_code == 403
+
+    # scope org: token o1, path o1 OK / o2 KO
+    r = client.get(
+        "/api/v1/rbac_demo/scoped/o1", headers={"Authorization": f"Bearer {t_mgr}"}
+    )
+    assert r.status_code == 200
+    r = client.get(
+        "/api/v1/rbac_demo/scoped/o2", headers={"Authorization": f"Bearer {t_mgr}"}
+    )
+    assert r.status_code == 403


### PR DESCRIPTION
## Summary
- add org_memberships table and RBAC utilities
- demo RBAC router with role and org scope checks
- document RBAC roles matrix and add unit tests

## Testing
- `python -m ruff check backend`
- `python -m mypy --config-file backend/mypy.ini backend`
- `PYTHONPATH=backend python -m pytest -q -k rbac`

Please review docs/roadmap.md and propose updates if misaligned.

------
https://chatgpt.com/codex/tasks/task_e_68ad9aba361c8330931ea93ebcf4cc8a