### PR TITLE
Docs: Warnings CI (cheat sheet + scan scripts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ BE 8000 ; FE 5173 ; DB 5432 ; Redis 6379 ; Adminer 8080.
 ```powershell
 backend\.venv\Scripts\python -m ruff check backend
 backend\.venv\Scripts\python -m mypy --config-file backend\mypy.ini backend
-$Env:PYTHONPATH="backend"; backend\.venv\Scripts\python -m pytest -q -k "v1_endpoints"
+$Env$Env:PYTHONPATH="backend"; backend\.venv\Scripts\python -m pytest -q -k "v1_endpoints"
 ```
 ### Typing (passlib)
 
@@ -46,6 +46,25 @@ passlib n a pas de stubs officiels. Nous:
 
 * ignorons l import dans `backend/app/auth.py` via `# type: ignore[import-untyped]`
 * desactivons `import-untyped` uniquement pour `passlib.*` dans `backend/mypy.ini`
+
+## Warnings CI
+
+Un guide rapide est disponible dans `docs/WARNINGS.md` (codes, gravite, actions).
+Scanners:
+
+* Windows: `pwsh -NoLogo -NoProfile -File tools/warnings_scan.ps1`
+* Linux/macOS: `bash tools/warnings_scan.sh`
+
+TESTS (PS + curl):
+
+* Windows:
+
+  * backend.venv\Scripts\python -m ruff check backend
+  * backend.venv\Scripts\python -m mypy --config-file backend\mypy.ini backend
+  * $Env:PYTHONPATH="backend"; backend.venv\Scripts\python -m pytest -q
+* Linux/macOS:
+
+  * PYTHONPATH=backend backend/.venv/bin/python -m pytest -q
 
 ## README Policy
 
@@ -82,3 +101,4 @@ La CI utilise `npm ci` et echouera si le lockfile est absent.
 
 Q: Ca ne demarre pas ?
 R: Verifier python, npm et l existance du venv. Utiliser dev_down.ps1 puis dev_up.ps1.
+

--- a/docs/WARNINGS.md
+++ b/docs/WARNINGS.md
@@ -1,0 +1,35 @@
+# Warnings CI — guide rapide
+
+| Code / Message                     | Exemple / Contexte                                  | Cause probable                             | Gravite  | Action appliquee / a faire                                                                                     |
+| ---------------------------------- | --------------------------------------------------- | ------------------------------------------ | -------- | -------------------------------------------------------------------------------------------------------------- |
+| ruff E402                          | `Module level import not at top of file`            | Import avant configuration module-level    | Faible   | Imports reordonnes dans tests (FIXE).                                                                          |
+| mypy `import-untyped` (passlib)    | `Library stubs not installed for "passlib.context"` | Pas de stubs types officiels pour passlib  | Faible   | Ignore cible: `# type: ignore[import-untyped]` + `backend/mypy.ini` limite a `passlib.*` (FIXE).               |
+| `warn_unused_ignores` (mypy)       | Ignore non justifie                                 | Inline ignore redondant                    | Faible   | Maintien d’un seul ignore inline et regle `disable_error_code=import-untyped` sur `passlib.*` => pas “unused”. |
+| TestClient -> httpx requis         | `RuntimeError: starlette.testclient requires httpx` | Dev dep manquante                          | Faible   | Ajout `httpx` dans `backend/requirements-dev.txt` (FIXE).                                                      |
+| SQLite `PermissionError` unlink    | `WinError 32` sur cleanup \*.db                     | Handle Windows file locks                  | Faible   | `_unlink_with_retry()` dans tests (FIXE).                                                                      |
+| pwsh `if exist`                    | `Missing '(' after 'if'`                            | Syntaxe CMD au lieu de PowerShell          | Faible   | Remplace par `if (Test-Path ...) { ... }` (FIXE).                                                              |
+| “no such table: accounts” (pytest) | OperationalError pendant un endpoint                | Engine lie a mauvaise URL avant migrations | Majeur\* | Rebind DB dans `create_app()` via `set_database_url()` (FIXE). (*erreur runtime, pas “warning”)               |
+
+## Politique
+
+* **Ruff**: warnings = dette faible; on corrige immediatement si simple.
+* **Mypy**: absence de stubs tiers = OK si ignore cible et documente.
+* **Runtime**: toute erreur (ex. table manquante) = **bloquante** jusqu’au correctif.
+* **DeprecationWarnings**: suivis dans PR mensuelle deps (voir README “Dependances”).
+
+## Commandes utiles
+
+```powershell
+# Windows
+backend\.venv\Scripts\python -m ruff check backend
+backend\.venv\Scripts\python -m mypy --config-file backend\mypy.ini backend
+$Env:PYTHONPATH="backend"; backend\.venv\Scripts\python -m pytest -q
+```
+
+```bash
+# Linux/macOS (degrade)
+PYTHONPATH=backend backend/.venv/bin/python -m ruff check backend
+PYTHONPATH=backend backend/.venv/bin/python -m mypy --config-file backend/mypy.ini backend
+PYTHONPATH=backend backend/.venv/bin/python -m pytest -q
+```
+

--- a/tools/warnings_scan.ps1
+++ b/tools/warnings_scan.ps1
@@ -1,0 +1,30 @@
+Param(
+    [switch]$Json
+)
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version Latest
+
+$py = "backend\.venv\Scripts\python.exe"
+$results = [ordered]@{}
+
+Write-Host "[warnings-scan] Ruff..." -ForegroundColor Cyan
+& $py -m ruff check backend | Tee-Object -Variable ruffOut | Out-Null
+$results["ruff_ok"] = $LASTEXITCODE -eq 0
+$results["ruff_lines"] = ($ruffOut | Measure-Object -Line).Lines
+
+Write-Host "[warnings-scan] Mypy..." -ForegroundColor Cyan
+& $py -m mypy --config-file backend\mypy.ini backend | Tee-Object -Variable mypyOut | Out-Null
+$results["mypy_ok"] = $LASTEXITCODE -eq 0
+$results["mypy_lines"] = ($mypyOut | Measure-Object -Line).Lines
+
+Write-Host "[warnings-scan] Pytest..." -ForegroundColor Cyan
+$Env:PYTHONPATH="backend"
+& $py -m pytest -q --disable-warnings --maxfail=1 | Tee-Object -Variable pyOut | Out-Null
+$results["pytest_ok"] = $LASTEXITCODE -eq 0
+
+if ($Json) {
+    $results | ConvertTo-Json -Compress
+} else {
+    Write-Host "[warnings-scan] ruff_ok=$($results["ruff_ok"]) mypy_ok=$($results["mypy_ok"]) pytest_ok=$($results["pytest_ok"])" -ForegroundColor Green
+}
+

--- a/tools/warnings_scan.sh
+++ b/tools/warnings_scan.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+py="backend/.venv/bin/python"
+echo "[warnings-scan] Ruff..."
+$py -m ruff check backend || true
+echo "[warnings-scan] Mypy..."
+$py -m mypy --config-file backend/mypy.ini backend || true
+echo "[warnings-scan] Pytest..."
+PYTHONPATH=backend $py -m pytest -q --disable-warnings --maxfail=1 || true
+echo "[warnings-scan] done"
+


### PR DESCRIPTION
## Summary
- document common CI warnings and policy in `docs/WARNINGS.md`
- add PowerShell and bash `warnings_scan` scripts
- link warning guide and scanner commands from README

## Testing
- `python -m ruff check backend`
- `python -m mypy --config-file backend/mypy.ini backend`
- `PYTHONPATH=backend python -m pytest -q`
- `bash tools/warnings_scan.sh`
- ❌ `pwsh -NoLogo -NoProfile -File tools/warnings_scan.ps1` (pwsh missing)

Please re-read docs/ROADMAP.md and propose a patch if there's divergence.


------
https://chatgpt.com/codex/tasks/task_e_68ada726459c83308e50f070c0a07801