### PR TITLE
Jalon 7 - Redis cache basique (listages lourds + TTL + invalidation + tests HIT/MISS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ DB_PASSWORD=cc_pass
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
+# Cache
+REDIS_URL=fakeredis://
+CACHE_TTL_SECONDS=60
+
 # Auth/JWT (dev uniquement; ne pas utiliser ces valeurs en prod)
 
 SECRET_KEY=dev-secret-not-for-prod

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Voir .env.example. Pas de secrets dans le repo.
 
 BE 8000 ; FE 5173 ; DB 5432 ; Redis 6379 ; Adminer 8080.
 
+## Cache
+
+Un cache Redis (TTL court) couvre les listages projects/missions. Voir `backend/README.md#cache-jalon-7` pour details et tests.
+
 ## Tests/Lint
 
 ```powershell

--- a/backend/README.md
+++ b/backend/README.md
@@ -174,3 +174,28 @@ ACCEPTANCE:
 * `assignments:{id}:status` refuse ACCEPTED en cas de conflit horaire.
 * `conflicts/user/{uid}` retourne les overlaps pour ACCEPTED.
 * CI verte (ruff/mypy/pytest). Viser >=70% de cov pour ce jalon (selon roadmap).
+
+## Cache (Jalon 7)
+
+* Objectif: accelerer les listages lourds (projects, missions).
+* Client: `redis` si `REDIS_URL` pointe vers un serveur, sinon `fakeredis://` en dev/test.
+* TTL: `CACHE_TTL_SECONDS` (defaut 60s).
+* Invalidation:
+  * tag `projects:<org_id>` sur /projects (create/update/delete)
+  * tag `missions:<org_id>` sur /missions (create/duplicate)
+* En-tete `X-Cache`: renvoye par les listages pour debug (HIT/MISS).
+* Extension future: etendre a d autres listages si besoin.
+
+### Tests
+
+```powershell
+$Env:REDIS_URL="fakeredis://"
+$Env:PYTHONPATH="backend"
+backend\.venv\Scripts\python -m pytest -q -k "cache"
+```
+
+ACCEPTANCE:
+
+* HIT/MISS observe via `X-Cache` sur projects/missions.
+* Ecritures invalident et provoquent un MISS ensuite.
+* CI verte (ruff, mypy, pytest). Roadmap J7 respectee.

--- a/backend/app/cache.py
+++ b/backend/app/cache.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+import json
+import os
+from typing import Any, Iterable, Optional, Tuple
+
+DEFAULT_TTL = int(os.getenv("CACHE_TTL_SECONDS", "60"))
+REDIS_URL = os.getenv("REDIS_URL", "fakeredis://")
+
+redis: Any = None
+fakeredis: Any = None
+try:
+    import redis as redis_lib
+    redis = redis_lib
+except Exception:  # pragma: no cover
+    redis = None
+
+try:
+    import fakeredis as fakeredis_lib
+    fakeredis = fakeredis_lib
+except Exception:  # pragma: no cover
+    fakeredis = None
+
+
+class Cache:
+    def __init__(self, client: Any):
+        self.client = client
+
+    def _k(self, key: str) -> str:
+        return f"cc:{key}"
+
+    def _tagk(self, tag: str) -> str:
+        return f"cc:tag:{tag}"
+
+    def get_json(self, key: str) -> Optional[Any]:
+        raw = self.client.get(self._k(key))
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except Exception:  # pragma: no cover
+            return None
+
+    def set_json(
+        self,
+        key: str,
+        value: Any,
+        ttl: Optional[int] = None,
+        tags: Optional[Iterable[str]] = None,
+    ) -> None:
+        v = json.dumps(value, separators=(",", ":"), ensure_ascii=True)
+        self.client.set(self._k(key), v, ex=ttl or DEFAULT_TTL)
+        if tags:
+            for t in tags:
+                self.client.sadd(self._tagk(t), self._k(key))
+
+    def invalidate_tags(self, tags: Iterable[str]) -> int:
+        deleted = 0
+        for t in tags:
+            tag_key = self._tagk(t)
+            members = list(self.client.smembers(tag_key) or [])
+            if members:
+                self.client.delete(*members)
+                deleted += len(members)
+            self.client.delete(tag_key)
+        return deleted
+
+    def cached_list(
+        self,
+        key: str,
+        builder,
+        ttl: Optional[int],
+        tags: Iterable[str],
+    ) -> Tuple[Any, bool]:
+        v = self.get_json(key)
+        if v is not None:
+            return v, True
+        data = builder()
+        self.set_json(key, data, ttl=ttl, tags=tags)
+        return data, False
+
+
+_singleton: Optional[Cache] = None
+
+
+def get_cache() -> Cache:
+    global _singleton
+    if _singleton:
+        return _singleton
+    url = REDIS_URL
+    cli: Any
+    if url.startswith("fakeredis://"):
+        if not fakeredis:
+            raise RuntimeError("fakeredis non disponible")
+        cli = fakeredis.FakeRedis(decode_responses=True)
+    else:
+        if not redis:
+            raise RuntimeError("redis non disponible")
+        cli = redis.Redis.from_url(url, decode_responses=True)
+    _singleton = Cache(cli)
+    return _singleton

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -5,3 +5,4 @@ mypy==1.10.0
 pytest==8.2.0
 pytest-cov==5.0.0
 httpx==0.27.2   # requis par fastapi.testclient/starlette.testclient
+fakeredis==2.23.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,4 @@ bcrypt==4.2.0
 # Pydantic EmailStr support
 
 email-validator==2.1.1
+redis==5.0.7

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,0 +1,122 @@
+import os
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+TEST_DB_PATH = Path("backend/test_cache.db").resolve()
+TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
+
+
+def _cleanup() -> None:
+    if TEST_DB_PATH.exists():
+        try:
+            TEST_DB_PATH.unlink(missing_ok=True)
+        except PermissionError:
+            pass
+
+
+def setup_module(module) -> None:  # noqa: ANN001
+    _cleanup()
+
+
+def teardown_module(module) -> None:  # noqa: ANN001
+    _cleanup()
+
+
+def _upgrade(url: str) -> None:
+    _cleanup()
+    os.environ["DB_URL"] = url
+    os.environ["DATABASE_URL"] = url
+    os.environ["REDIS_URL"] = "fakeredis://"
+    cfg = Config("backend/alembic.ini")
+    command.upgrade(cfg, "head")
+
+
+def _client() -> TestClient:
+    from app.main import create_app
+
+    app = create_app()
+    return TestClient(app)
+
+
+def test_projects_cache_hit_miss_and_invalidation() -> None:
+    os.environ["ENV"] = "dev"
+    _upgrade(TEST_DB_URL)
+
+    eng = create_engine(TEST_DB_URL, future=True)
+    with eng.begin() as c:
+        c.execute(
+            text(
+                "INSERT INTO orgs (id, name, created_at, updated_at) VALUES ('o1','Org',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        c.execute(
+            text(
+                "INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at) VALUES ('a1','o1','mgr@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        c.execute(
+            text(
+                "INSERT INTO org_memberships (id, org_id, account_id, role, created_at, updated_at) VALUES ('m1','o1','a1','manager',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+    from app.auth import create_access_token
+
+    token = create_access_token("a1", "o1")
+    client = _client()
+
+    r1 = client.get("/api/v1/projects", headers={"Authorization": f"Bearer {token}"})
+    assert r1.status_code == 200
+    assert r1.headers.get("X-Cache") == "MISS"
+
+    r2 = client.get("/api/v1/projects", headers={"Authorization": f"Bearer {token}"})
+    assert r2.status_code == 200
+    assert r2.headers.get("X-Cache") == "HIT"
+
+    r3 = client.post(
+        "/api/v1/projects",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"name": "P1", "status": "ACTIVE"},
+    )
+    assert r3.status_code == 200
+    r4 = client.get("/api/v1/projects", headers={"Authorization": f"Bearer {token}"})
+    assert r4.status_code == 200
+    assert r4.headers.get("X-Cache") == "MISS"
+
+
+def test_missions_cache_hit_miss() -> None:
+    os.environ["ENV"] = "dev"
+    _upgrade(TEST_DB_URL)
+
+    eng = create_engine(TEST_DB_URL, future=True)
+    with eng.begin() as c:
+        c.execute(
+            text(
+                "INSERT INTO orgs (id, name, created_at, updated_at) VALUES ('o1','Org',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        c.execute(
+            text(
+                "INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at) VALUES ('a1','o1','mgr@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+        c.execute(
+            text(
+                "INSERT INTO org_memberships (id, org_id, account_id, role, created_at, updated_at) VALUES ('m1','o1','a1','manager',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+            )
+        )
+    from app.auth import create_access_token
+
+    token = create_access_token("a1", "o1")
+    client = _client()
+
+    r1 = client.get("/api/v1/missions", headers={"Authorization": f"Bearer {token}"})
+    assert r1.status_code == 200
+    assert r1.headers.get("X-Cache") == "MISS"
+
+    r2 = client.get("/api/v1/missions", headers={"Authorization": f"Bearer {token}"})
+    assert r2.status_code == 200
+    assert r2.headers.get("X-Cache") == "HIT"


### PR DESCRIPTION
## Summary
- add Redis/fakeredis cache helper with TTL and tag invalidation
- cache project/mission listings and expose X-Cache header
- document cache strategy and env vars

## Testing
- `backend/.venv/bin/python -m ruff check backend`
- `backend/.venv/bin/python -m mypy --config-file backend/mypy.ini backend`
- `REDIS_URL=fakeredis:// PYTHONPATH=backend backend/.venv/bin/python -m pytest -q -k cache`

Please review `docs/ROADMAP.md` and propose patches if any divergence is found.

------
https://chatgpt.com/codex/tasks/task_e_68adaa7e9b748330a094ef4e6a3dada8