### PR TITLE
Fix CI: npm registry 403 + test_cache collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
+      - name: Force npm registry public (CI)
+        run: |
+          echo "registry=https://registry.npmjs.org/" > .npmrc
+          echo "always-auth=false" >> .npmrc
+          echo "fund=false" >> .npmrc
+          echo "audit=false" >> .npmrc
       - name: Cache npm
         uses: actions/cache@v4
         with:
@@ -50,7 +56,7 @@ jobs:
       - name: Frontend lint
         run: |
           cd frontend
-          npm ci
+          npm ci --no-audit --no-fund --registry=https://registry.npmjs.org/
           npm run lint
   docs-guard:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ BE 8000 ; FE 5173 ; DB 5432 ; Redis 6379 ; Adminer 8080.
 
 Un cache Redis (TTL court) couvre les listages projects/missions. Voir `backend/README.md#cache-jalon-7` pour details et tests.
 
+## NPM registry (CI)
+
+En CI, on force le registry public npmjs pour eviter des 403 si un `.npmrc` prive ou une policy force l auth:
+
+* Workflow: etape "Force npm registry public (CI)" + `npm ci --registry=https://registry.npmjs.org/`
+* Local: `npm config set registry https://registry.npmjs.org/` si besoin.
+
 ## Tests/Lint
 
 ```powershell

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -93,24 +93,25 @@ def test_missions_cache_hit_miss() -> None:
 
     eng = create_engine(TEST_DB_URL, future=True)
     with eng.begin() as c:
+        # Utiliser un jeu distinct pour eviter les collisions avec le test precedent
         c.execute(
             text(
-                "INSERT INTO orgs (id, name, created_at, updated_at) VALUES ('o1','Org',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                "INSERT INTO orgs (id, name, created_at, updated_at) VALUES ('o2','Org2',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
             )
         )
         c.execute(
             text(
-                "INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at) VALUES ('a1','o1','mgr@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                "INSERT INTO accounts (id, org_id, email, is_active, created_at, updated_at) VALUES ('a2','o2','mgr2@example.com',1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
             )
         )
         c.execute(
             text(
-                "INSERT INTO org_memberships (id, org_id, account_id, role, created_at, updated_at) VALUES ('m1','o1','a1','manager',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
+                "INSERT INTO org_memberships (id, org_id, account_id, role, created_at, updated_at) VALUES ('m2','o2','a2','manager',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)"
             )
         )
     from app.auth import create_access_token
 
-    token = create_access_token("a1", "o1")
+    token = create_access_token("a2", "o2")
     client = _client()
 
     r1 = client.get("/api/v1/missions", headers={"Authorization": f"Bearer {token}"})

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,4 @@
+registry=https://registry.npmjs.org/
+always-auth=false
+audit=false
+fund=false


### PR DESCRIPTION
## Summary
- fix(ci): force npmjs registry in workflow and ship .npmrc for public registry usage
- fix(test): isolate missions cache test data to avoid UNIQUE constraint errors
- docs: document NPM registry override in root README

## Testing
- `cd frontend && npm ci --registry=https://registry.npmjs.org/ && npm run lint`
- `backend\.venv\Scripts\python -m ruff check backend` *(fails: command not found)*
- `backend/.venv/bin/python -m ruff check backend`
- `backend/.venv/bin/python -m mypy --config-file backend/mypy.ini backend`
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adae1f4aac8330aaebe5669ab91ac8