### PR TITLE
Fix CI frontend: pin npm userconfig (.npmrc) vers registry public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Rappel lecture docs/roadmap.md
-        run: |
-          echo "Relire docs/ROADMAP.md et aligner le code; proposer patch si divergence."
+        run: echo "Relire docs/ROADMAP.md (source de verite)."
   backend:
     runs-on: windows-latest
     steps:
@@ -40,12 +39,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
-      - name: Force npm registry public (CI)
+      - name: Ecrire .npmrc de projet (registry public)
+        shell: bash
         run: |
-          echo "registry=https://registry.npmjs.org/" > .npmrc
-          echo "always-auth=false" >> .npmrc
-          echo "fund=false" >> .npmrc
-          echo "audit=false" >> .npmrc
+          cat > frontend/.npmrc <<'EOF'
+          registry=https://registry.npmjs.org/
+          always-auth=false
+          audit=false
+          fund=false
+          strict-ssl=true
+          EOF
       - name: Cache npm
         uses: actions/cache@v4
         with:
@@ -53,10 +56,16 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Frontend lint
+      - name: Install + Lint (registry force)
+        shell: bash
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/frontend/.npmrc
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
           cd frontend
-          npm ci --no-audit --no-fund --registry=https://registry.npmjs.org/
+          echo "[debug] npm version: $(npm --version)"
+          echo "[debug] registry (pre): $(npm config get registry)"
+          npm ci --no-audit --no-fund
           npm run lint
   docs-guard:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,11 +38,25 @@ BE 8000 ; FE 5173 ; DB 5432 ; Redis 6379 ; Adminer 8080.
 Un cache Redis (TTL court) couvre les listages projects/missions. Voir `backend/README.md#cache-jalon-7` pour details et tests.
 
 ## NPM registry (CI)
+En CI, nous **pinnons** le fichier userconfig npm sur `frontend/.npmrc` via la variable d env `NPM_CONFIG_USERCONFIG` pour garantir l usage du **registry public**:
 
-En CI, on force le registry public npmjs pour eviter des 403 si un `.npmrc` prive ou une policy force l auth:
+* Workflow: ecriture de `frontend/.npmrc` + `NPM_CONFIG_USERCONFIG=${{ github.workspace }}/frontend/.npmrc`
+* Commandes:
 
-* Workflow: etape "Force npm registry public (CI)" + `npm ci --registry=https://registry.npmjs.org/`
-* Local: `npm config set registry https://registry.npmjs.org/` si besoin.
+```bash
+cd frontend
+npm ci --no-audit --no-fund
+npm run lint
+```
+
+Astuce debug CI:
+
+```bash
+npm --version
+npm config get registry
+```
+
+Si un `.npmrc` global force une registry privee, ce pin l ignore.
 
 ## Tests/Lint
 

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -2,3 +2,4 @@ registry=https://registry.npmjs.org/
 always-auth=false
 audit=false
 fund=false
+strict-ssl=true


### PR DESCRIPTION
## Summary
- pin NPM user config to `frontend/.npmrc` to force public registry in CI
- document registry pinning and debug hints

## Testing
- `cd frontend && npm ci --registry=https://registry.npmjs.org/ --no-audit --no-fund`
- `npm run lint`
- `bash tools/docs_guard.sh`
- `bash tools/readme_check.sh`

Veuillez relire `docs/ROADMAP.md` (source de vérité) et proposer un patch si nécessaire.

------
https://chatgpt.com/codex/tasks/task_e_68adb2888ee48330a16ce7091c5a5410