### PR TITLE
Jalon 8 - Observabilite backend (/metrics, logs JSON, probes, obs-smoke)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,6 @@ ENV=dev
 TZ=UTC
 API_BASE=http://localhost:8000
 WEB_BASE=http://localhost:5173
-LOG_LEVEL=INFO
 
 # Backend
 
@@ -40,3 +39,7 @@ REFRESH_TOKEN_DAYS=7
 
 # Invitations (TTL heures)
 INVITE_TOKEN_TTL_HOURS=48
+
+# Observabilite
+LOG_LEVEL=INFO
+METRICS_ENABLED=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,28 @@ jobs:
           echo "[debug] registry (pre): $(npm config get registry)"
           npm ci --no-audit --no-fund
           npm run lint
+  obs-smoke:
+    runs-on: windows-latest
+    needs: [backend]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.10" }
+      - name: Deps minimales
+        shell: pwsh
+        run: |
+          python -m venv backend/.venv
+          backend\.venv\Scripts\pip install -r backend\requirements.txt
+          if (Test-Path "backend\requirements-dev.txt") { backend\.venv\Scripts\pip install -r backend\requirements-dev.txt }
+      - name: Obs smoke (pytest -k obs)
+        shell: pwsh
+        env:
+          PYTHONPATH: backend
+        run: |
+          backend\.venv\Scripts\python -m pytest -q -k "obs or readiness or metrics"
   docs-guard:
     runs-on: ubuntu-latest
-    needs: [backend, frontend]
+    needs: [backend, frontend, obs-smoke]
     steps:
       - uses: actions/checkout@v4
       - name: Docs guard

--- a/PS1/obs_smoke.ps1
+++ b/PS1/obs_smoke.ps1
@@ -1,0 +1,5 @@
+Param()
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version Latest
+$Env:PYTHONPATH="backend"
+backend.venv\Scripts\python -m pytest -q -k "obs or readiness or metrics"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ pwsh -NoLogo -NoProfile -File PS1/init_repo.ps1
 pwsh -NoLogo -NoProfile -File PS1/dev_up.ps1
 # Ouvrir: http://localhost:5173 et GET http://localhost:8000/api/v1/ping
 ```
+## CI gates actifs (extrait)
+
+* backend: ruff, mypy, pytest
+* frontend: npm ci + lint (registry public force)
+* obs-smoke: tests ciblant observabilite (/metrics, probes)
+  Relire `docs/ROADMAP.md` avant toute PR.
+
 
 ## Scripts clefs
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -199,3 +199,29 @@ ACCEPTANCE:
 * HIT/MISS observe via `X-Cache` sur projects/missions.
 * Ecritures invalident et provoquent un MISS ensuite.
 * CI verte (ruff, mypy, pytest). Roadmap J7 respectee.
+
+## Observabilite (Jalon 8)
+
+* /metrics (Prometheus) expose des compteurs, histos et gauge: `app_requests_total`, `app_request_duration_seconds`, `app_inflight_requests`.
+* Logs JSON par requete: `request_id`, `trace_id`, `method`, `path`, `status`, `duration_ms`.
+* Probes:
+  * `/livez` -> 200 si process en vie
+  * `/readyz` -> 200 si DB OK (`SELECT 1`), sinon 503
+* Env:
+  * `LOG_LEVEL` (defaut INFO)
+  * `METRICS_ENABLED` (true/false)
+* Scrape Prometheus (exemple):
+
+```
+scrape_configs:
+  - job_name: "cc-backend"
+    static_configs: [{ targets: ["localhost:8000"] }]
+    metrics_path: /metrics
+```
+
+* Tests:
+
+```powershell
+$Env:PYTHONPATH="backend"
+backend\.venv\Scripts\python -m pytest -q -k "obs or readiness or metrics"
+```

--- a/backend/app/logging_setup.py
+++ b/backend/app/logging_setup.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
+        data: Dict[str, Any] = {
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        # Extra champs si presents
+        for k in ("request_id", "trace_id", "method", "path", "status", "duration_ms"):
+            v = getattr(record, k, None)
+            if v is not None:
+                data[k] = v
+        return json.dumps(data, separators=(",", ":"), ensure_ascii=True)
+
+
+def configure_logging() -> None:
+    level = os.getenv("LOG_LEVEL", "INFO").upper()
+    root = logging.getLogger()
+    root.setLevel(level)
+    # Nettoie handlers existants (evite doublons en tests)
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    h = logging.StreamHandler()
+    h.setFormatter(JsonFormatter())
+    root.addHandler(h)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,26 +1,87 @@
 from __future__ import annotations
+
+import logging
 import os
 import uuid
-from fastapi import FastAPI, Request
+from typing import Any, Dict
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse
+from sqlalchemy import create_engine, text
+
 from .settings import settings
-from .logging_conf import setup as setup_logging
+from .logging_setup import configure_logging
+from .observability import setup_metrics
+from .db import set_database_url
 from .api import router as api_router
 from .api_auth import router as auth_router
 from .api_rbac_demo import router as rbac_demo_router
-from .db import set_database_url
-
-from .api_v1_projects import router as projects_router
-from .api_v1_missions import router as missions_router
 from .api_v1_assignments import router as assignments_router
-from .api_v1_invitations import router as invitations_router
-from .api_v1_users import router as users_router
 from .api_v1_availability import router as availability_router
 from .api_v1_conflicts import router as conflicts_router
-from .api_v1_rates import router as rates_router
+from .api_v1_invitations import router as invitations_router
+from .api_v1_missions import router as missions_router
 from .api_v1_orgs import router as orgs_router
+from .api_v1_projects import router as projects_router
+from .api_v1_rates import router as rates_router
+from .api_v1_users import router as users_router
+
+
+# Middleware request_id + logs JSON
+async def add_request_id(request: Request, call_next):
+    req_id = request.headers.get(settings.request_id_header) or uuid.uuid4().hex
+    request.state.request_id = req_id
+    request.state.trace_id = req_id
+    logger = logging.getLogger("app.request")
+    response: Response
+    try:
+        response = await call_next(request)
+    finally:  # noqa: WPS100
+        pass
+    try:
+        duration_ms = getattr(request.state, "_duration_ms", None)
+    except Exception:  # pragma: no cover - defensive
+        duration_ms = None
+    logger.info(
+        "http_request",
+        extra={
+            "request_id": req_id,
+            "trace_id": req_id,
+            "method": request.method,
+            "path": request.url.path,
+            "status": getattr(response, "status_code", None),
+            "duration_ms": duration_ms,
+        },
+    )
+    response.headers[settings.request_id_header] = req_id
+    return response
+
+
+# Middleware pour mesurer la duree en ms (pour logs)
+async def add_timer(request: Request, call_next):
+    import time
+
+    start = time.perf_counter()
+    response = await call_next(request)
+    request.state._duration_ms = int((time.perf_counter() - start) * 1000)
+    return response
+
+
+def _readiness_check() -> Dict[str, Any]:
+    url = os.getenv("DATABASE_URL") or os.getenv("DB_URL")
+    if not url:
+        return {"db": "missing-url", "ok": False}
+    try:
+        eng = create_engine(url, future=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1"))
+        return {"db": "ok", "ok": True}
+    except Exception as e:  # pragma: no cover (rare)
+        return {"db": f"error:{type(e).__name__}", "ok": False}
+
 
 def create_app() -> FastAPI:
-    setup_logging()
+    configure_logging()
     # Rebind DB a chaque creation d app (prend en compte DATABASE_URL courant)
     url = os.getenv("DATABASE_URL", "sqlite:///./backend/dev.db")
     set_database_url(url)
@@ -28,22 +89,29 @@ def create_app() -> FastAPI:
 
     app = FastAPI(title=settings.app_name)
 
-    @app.middleware("http")
-    async def add_request_id(request: Request, call_next):
-        rid = request.headers.get(settings.request_id_header) or str(uuid.uuid4())
-        request.state.request_id = rid
-        response = await call_next(request)
-        response.headers[settings.request_id_header] = rid
-        return response
+    # Observabilite
+    app.middleware("http")(add_timer)
+    app.middleware("http")(add_request_id)
+    metrics_enabled = os.getenv("METRICS_ENABLED", "true").lower() == "true"
+    setup_metrics(app, enabled=metrics_enabled)
 
     @app.get("/healthz")
-    def healthz() -> dict[str, str]:
+    def healthz() -> Dict[str, str]:
         return {"status": "ok"}
+
+    @app.get("/livez")
+    def livez() -> Dict[str, str]:
+        return {"status": "live"}
+
+    @app.get("/readyz")
+    def readyz() -> JSONResponse:
+        status = _readiness_check()
+        code = 200 if status.get("ok") else 503
+        return JSONResponse({"status": status}, status_code=code)
 
     app.include_router(api_router)
     app.include_router(auth_router)
     app.include_router(rbac_demo_router)
-
     app.include_router(projects_router)
     app.include_router(missions_router)
     app.include_router(assignments_router)
@@ -53,6 +121,7 @@ def create_app() -> FastAPI:
     app.include_router(conflicts_router)
     app.include_router(rates_router)
     app.include_router(orgs_router)
+
     return app
 
 

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import time
+from typing import Callable, Awaitable
+
+from prometheus_client import (
+    Counter,
+    Histogram,
+    Gauge,
+    CONTENT_TYPE_LATEST,
+    generate_latest,
+)
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response, PlainTextResponse
+from starlette.routing import Match
+
+# Metrics (noms stables)
+
+REQUESTS = Counter(
+    "app_requests_total",
+    "Total des requetes HTTP",
+    ["method", "path", "status"],
+)
+DURATION = Histogram(
+    "app_request_duration_seconds",
+    "Duree des requetes HTTP (secondes)",
+    ["method", "path", "status"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+INFLIGHT = Gauge(
+    "app_inflight_requests",
+    "Requetes HTTP en cours",
+)
+
+def _path_template(request: Request) -> str:
+    # Essaie de trouver le pattern de route (ex: /api/v1/projects)
+    for route in request.app.router.routes:
+        match, _ = route.matches(request.scope)
+        if match == Match.FULL:
+            try:
+                return route.path
+            except Exception:
+                continue
+    return request.url.path
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        path = _path_template(request)
+        method = request.method.upper()
+        start = time.perf_counter()
+        INFLIGHT.inc()
+        try:
+            response = await call_next(request)
+            status = str(response.status_code)
+            elapsed = time.perf_counter() - start
+            REQUESTS.labels(method=method, path=path, status=status).inc()
+            DURATION.labels(method=method, path=path, status=status).observe(elapsed)
+            return response
+        finally:
+            INFLIGHT.dec()
+
+
+async def metrics_endpoint(_: Request) -> Response:
+    output = generate_latest()  # default registry
+    return PlainTextResponse(output.decode("utf-8"), media_type=CONTENT_TYPE_LATEST)
+
+
+def setup_metrics(app, enabled: bool = True) -> None:
+    if not enabled:
+        return
+    app.add_route("/metrics", metrics_endpoint, methods=["GET"])
+    app.add_middleware(MetricsMiddleware)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,6 @@ bcrypt==4.2.0
 
 email-validator==2.1.1
 redis==5.0.7
+
+# Observabilite
+prometheus-client==0.20.0

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+
+import os
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+
+TEST_DB_PATH = Path("backend/test_obs.db").resolve()
+TEST_DB_URL = f"sqlite:///{TEST_DB_PATH}"
+
+
+def _upgrade(url: str) -> None:
+    os.environ["DB_URL"] = url
+    os.environ["DATABASE_URL"] = url
+    cfg = Config("backend/alembic.ini")
+    command.upgrade(cfg, "head")
+
+
+def _client():
+    from app.main import create_app
+
+    app = create_app()
+    return TestClient(app)
+
+
+def test_metrics_endpoint_exposes_metrics() -> None:
+    os.environ["ENV"] = "dev"
+    os.environ["METRICS_ENABLED"] = "true"
+    client = _client()
+    r = client.get("/metrics")
+    assert r.status_code == 200
+    assert "app_request_duration_seconds" in r.text
+
+
+def test_probes_livez_readyz_ok() -> None:
+    os.environ["ENV"] = "dev"
+    _upgrade(TEST_DB_URL)
+    client = _client()
+
+    r1 = client.get("/livez")
+    assert r1.status_code == 200
+    assert r1.json()["status"] == "live"
+
+    r2 = client.get("/readyz")
+    assert r2.status_code == 200
+    assert r2.json()["status"]["ok"] is True
+
+
+def test_logs_json_have_ids() -> None:
+    os.environ["ENV"] = "dev"
+    client = _client()
+    r = client.get("/healthz", headers={"X-Request-ID": "rid123"})
+    assert r.status_code == 200
+    assert r.headers["X-Request-ID"] == "rid123"


### PR DESCRIPTION
## Summary
- expose Prometheus metrics and probes for liveness/readiness
- switch backend logging to JSON and surface request ids
- add obs-smoke job & docs for observability

## Testing
- `backend/.venv/bin/python -m ruff check backend`
- `backend/.venv/bin/mypy --config-file backend/mypy.ini backend`
- `PYTHONPATH=backend backend/.venv/bin/python -m pytest -q -k "obs or readiness or metrics"`

Please read `docs/ROADMAP.md` (source de verite).

------
https://chatgpt.com/codex/tasks/task_e_68adc69b495483309783a312cf75ab0e