### PR TITLE
Fix docker-smoke: PYTHONPATH image + run corrige

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Build backend image
         run: docker build -t cc-backend:ci -f backend/Dockerfile .
       - name: Run backend container
-        run: docker run -d --rm -p 8000:8000 --name cc-backend ci_dummy cc-backend:ci || docker run -d --rm -p 8000:8000 --name cc-backend cc-backend:ci
+        run: docker run -d --rm -p 8000:8000 --name cc-backend cc-backend:ci
       - name: Wait for healthz
         run: |
           for i in {1..30}; do

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,6 +20,9 @@ RUN python -m pip install -U pip && \
 # Copy source
 COPY backend /app/backend
 
+# Rendre importable le package "app" (sous /app/backend)
+ENV PYTHONPATH=/app/backend
+
 EXPOSE 8000
 
 # Start FastAPI (factory)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,6 +25,9 @@ pwsh -NoLogo -NoProfile -File PS1/smoke.ps1
 * Adminer: http://localhost:8080
 * Postgres: localhost:5432 (DB ${POSTGRES_DB}, user ${POSTGRES_USER})
 
+### Note image backend
+L image definit `ENV PYTHONPATH=/app/backend` afin que `uvicorn app.main:create_app` importe correctement le package `app` situe sous `/app/backend`. Sans cela, le process tomberait au demarrage (import error) et le port 8000 ne repondrait pas en smoke.
+
 ## Arret
 
 ```powershell


### PR DESCRIPTION
## Summary
- set PYTHONPATH in backend image so package app loads
- simplify docker-smoke run command
- document PYTHONPATH note for backend image

## Testing
- `docker build -t cc-backend:ci -f backend/Dockerfile .` (fails: docker not installed)
- `docker run -d --rm -p 8000:8000 --name cc-backend cc-backend:ci` (fails: docker not installed)
- `curl -sSf http://localhost:8000/healthz` (fails: cannot connect)

Labels: build, tests, docs-required

------
https://chatgpt.com/codex/tasks/task_e_68adda19d1c48330bafc19807588c283