### PR TITLE
Fix FE e2e auth labels (a11y + stabilisation)

### DIFF
--- a/PS1/e2e_repro.ps1
+++ b/PS1/e2e_repro.ps1
@@ -1,0 +1,17 @@
+#Requires -Version 7.0
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+Push-Location (Join-Path $PSScriptRoot "..\frontend")
+try {
+  if (Test-Path package-lock.json) {
+    npm ci
+  } else {
+    npm install
+  }
+  npx playwright install --with-deps
+  npm run test:e2e -- --project=chromium
+} finally {
+  Pop-Location
+}
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,6 +42,14 @@ npx playwright install --with-deps
 npm run test:e2e
 ```
 
+## Repro E2E (Windows)
+
+```powershell
+pwsh -File PS1/e2e_repro.ps1
+```
+
+> Les tests e2e ciblent les champs via `getByLabel`. Les pages doivent associer les labels aux inputs avec `htmlFor`/`id` pour garantir l’accessibilite et la stabilite des tests.
+
 ## CMD_TESTS
 
 # Windows

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -37,13 +37,24 @@ export function Login() {
       <h1 className="text-xl font-semibold mb-2">Login</h1>
       <form onSubmit={onSubmit} className="space-y-3">
         <div>
-          <label className="block text-sm">Email</label>
-          <input className="border px-3 py-2 w-full" {...register("email")} />
+          <label htmlFor="email" className="block text-sm">Email</label>
+          <input
+            id="email"
+            autoComplete="username"
+            className="border px-3 py-2 w-full"
+            {...register("email")}
+          />
           {errors.email && <p className="text-red-600 text-sm">Email invalide</p>}
         </div>
         <div>
-          <label className="block text-sm">Mot de passe</label>
-          <input type="password" className="border px-3 py-2 w-full" {...register("password")} />
+          <label htmlFor="password" className="block text-sm">Mot de passe</label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            className="border px-3 py-2 w-full"
+            {...register("password")}
+          />
           {errors.password && <p className="text-red-600 text-sm">Mot de passe invalide</p>}
         </div>
         {error && <p className="text-red-700 text-sm">{error}</p>}

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -33,6 +33,7 @@ test.describe("auth flow (login, garde, refresh)", () => {
     // aller sur une page protegee -> redir login
     await page.goto("/app");
     await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByLabel("Email")).toBeVisible();
 
     // login
     await page.getByLabel("Email").fill("sam@example.com");


### PR DESCRIPTION
## Summary
- associate login labels with inputs to enable a11y-friendly selectors
- ensure login field visible before filling in e2e
- document and script Windows e2e repro

## Testing
- `npm run lint`
- `npm run test -- --run`
- `npm run test:e2e -- --project=chromium` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install --with-deps` *(fails: Download failure, code=1)*
- `pwsh -NoLogo -NoProfile -Command "Set-Location frontend; npm ci; npx playwright install --with-deps; npm run test:e2e -- --project=chromium"` *(fails: command not found)*
- `pwsh -File PS1/e2e_repro.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae204faec88330bc774e4fc6229a07