### PR TITLE
Fix FE CI ENOENT (workspace)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,40 +34,38 @@ jobs:
         run: |
           backend\.venv\Scripts\python -m pytest -q --disable-warnings --maxfail=1
   frontend:
+    name: frontend (lint+unit+e2e-smoke)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with: { node-version: "20" }
-      - name: Ecrire .npmrc de projet (registry public)
-        shell: bash
-        run: |
-          cat > frontend/.npmrc <<'EOF'
-          registry=https://registry.npmjs.org/
-          always-auth=false
-          audit=false
-          fund=false
-          strict-ssl=true
-          EOF
-      - name: Cache npm
-        uses: actions/cache@v4
+
+      - name: Use Node LTS
+        uses: actions/setup-node@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Install deps
-        run: npm ci --no-audit --no-fund --workspace frontend
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install deps (FE)
+        run: npm ci --no-audit --no-fund
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
+
       - name: Lint (FE)
-        run: npm run lint --workspace frontend
+        run: npm run lint
+
       - name: Unit tests (FE)
-        run: npm run test --workspace frontend
-      - name: E2E smoke (FE, jalon 10)
+        run: npm run test
+
+      - name: E2E smoke (J10)
         env:
           E2E_BASE_URL: http://localhost:5173
-        run: npm run e2e:smoke --workspace frontend
+        run: npm run e2e:smoke
   obs-smoke:
     runs-on: windows-latest
     needs: [backend]

--- a/PS1/fe_ci.ps1
+++ b/PS1/fe_ci.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$fe = Join-Path $here "..\frontend"
+Set-Location $fe
+
+# Install
+npm ci --no-audit --no-fund
+# Browsers (local smoke)
+npx playwright install
+
+# Lints + tests
+npm run lint
+npm run test
+
+# Smoke e2e
+$env:E2E_BASE_URL = "http://localhost:5173"
+npm run e2e:smoke

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ npm config get registry
 
 Si un `.npmrc` global force une registry privee, ce pin l ignore.
 
+## CI Frontend (jalon 10)
+- Le repo **n utilise pas** de workspaces npm a la racine.
+- Toutes les commandes npm front s executent **dans `frontend/`**.
+- Local (Windows): `pwsh -NoLogo -NoProfile -File PS1/fe_ci.ps1`
+
 ## Tests/Lint
 
 ```powershell

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,8 +2,10 @@
 
 Base React + Vite.
 
-## Tests FE (jalon 10)
-- Lancer unit:    npm run -w frontend test
-- Lancer smoke:   npm run -w frontend e2e:smoke
-- Auth e2e:       npm run -w frontend e2e:auth   (active a partir du jalon 11)  [E2E_AUTH=1]
+## CI local (jalon 10)
+- Installation: `npm ci`
+- Lint: `npm run lint`
+- Unit: `npm run test`
+- E2E smoke: `E2E_BASE_URL=http://localhost:5173 npm run e2e:smoke`
 
+Note: Pas de `--workspace` au jalon 10; exécuter dans `frontend/`.


### PR DESCRIPTION
## Summary
- fix frontend CI workflow to run npm commands from frontend directory
- add Windows-first script for local frontend CI run
- document frontend CI flow in root and frontend README

## Testing
- `npm ci --no-audit --no-fund` (frontend)
- `npx playwright install` *(fails: ERR_SOCKET_CLOSED)*
- `npm run lint`
- `npm run test`
- `E2E_BASE_URL=http://localhost:5173 npm run e2e:smoke` *(fails: browsers missing)*
- `bash tools/docs_guard.sh`
- `bash tools/readme_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b3f2494cc48330bd8f473a54bd7ad6