### PR TITLE
fix(ci): backend mypy+ruff & storybook bash fix

### DIFF
--- a/.github/workflows/frontend-storybook.yml
+++ b/.github/workflows/frontend-storybook.yml
@@ -25,8 +25,7 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Lint (ts/eslint)
-        run: |
-          if (npm run -q lint 2>$null) { exit 0 } else { echo "lint script absent, skip"; exit 0; }
+        run: npm run lint --if-present
 
       - name: Build storybook
         run: npm run build-storybook -- --quiet
@@ -41,5 +40,4 @@ jobs:
           echo "storybook not ready"; exit 3
 
       - name: Bundle budget (size-limit)
-        run: |
-          if (npm run -q size 2>$null) { npm run size; } else { echo "size-limit absent, skip"; }
+        run: npm run size --if-present

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn==0.30.6
 pydantic==2.9.2
 requests==2.32.3
 typer==0.12.5
+pydantic-settings>=2.3,<3
 
 # DB & migrations
 


### PR DESCRIPTION
## Summary
- load `.env` via importlib to avoid hard dependency on python-dotenv during mypy
- add missing pydantic-settings runtime dependency
- fix storybook workflow lint and size steps to use bash-friendly npm commands

## Testing
- `backend/.venv/bin/python -m ruff check backend`
- `backend/.venv/bin/python -m mypy --config-file backend/mypy.ini backend`
- `npm run lint --if-present`
- `npm run build-storybook -- --quiet`
- `for i in {1..30}; do curl -sf http://127.0.0.1:6006/ && echo OK && break; sleep 1; done`


------
https://chatgpt.com/codex/tasks/task_e_68b4702decdc8330a507007a1a5f1bd5