### PR TITLE
fix(frontend): lint clean (no-empty, no-explicit-any, ban-ts-comment)

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createBrowserRouter, type RouteObject } from "react-router-dom";
 import { lazy } from "react";
 import { AppLayout } from "./ui/AppLayout";
 import { Home } from "./pages/Home";
@@ -12,7 +12,7 @@ function WithAuth({ element }: { element: JSX.Element }) {
   return <AuthProvider>{element}</AuthProvider>;
 }
 
-const routes: any[] = [
+const routes: RouteObject[] = [
   {
     path: "/",
     element: <WithAuth element={<AppLayout />} />,

--- a/frontend/tests/unit/http.test.ts
+++ b/frontend/tests/unit/http.test.ts
@@ -1,16 +1,29 @@
+// frontend/tests/unit/http.test.ts
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http } from "../../src/lib/http";
 
 describe("http()", () => {
-  const originalFetch = global.fetch;
-  beforeEach(() => { global.fetch = originalFetch as any; document.cookie = "csrf=abc"; });
+  const originalFetch: typeof fetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+    // jsdom sait gérer document.cookie
+    document.cookie = "csrf=abc";
+  });
 
   it("retries on 500 then succeeds", async () => {
-    const spy = vi.fn()
+    const spy = vi.fn<Parameters<typeof fetch>, Promise<Response>>();
+    spy
       .mockResolvedValueOnce(new Response("err", { status: 500 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type":"application/json" } }));
-    // @ts-ignore
-    global.fetch = spy;
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+
+    // cast sûr: on fournit bien une fn compatible fetch
+    globalThis.fetch = spy as unknown as typeof fetch;
 
     const res = await http<{ ok: boolean }>("/x");
     expect(res.ok).toBe(true);
@@ -18,8 +31,14 @@ describe("http()", () => {
   });
 
   it("throws on 400", async () => {
-    // @ts-ignore
-    global.fetch = vi.fn().mockResolvedValue(new Response("nope", { status: 400, statusText: "Bad Request" }));
+    const spy = vi
+      .fn<Parameters<typeof fetch>, Promise<Response>>()
+      .mockResolvedValue(
+        new Response("nope", { status: 400, statusText: "Bad Request" })
+      );
+
+    globalThis.fetch = spy as unknown as typeof fetch;
+
     await expect(http("/y")).rejects.toMatchObject({ status: 400 });
   });
 });


### PR DESCRIPTION
## Summary
- improve error handling in fetch helper and avoid empty catch
- type router configuration with RouteObject instead of any
- rewrite http.test.ts to mock fetch without `any` or `@ts-ignore`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1134/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68b47e6989848330afd8af970e790833