### PR TITLE
feat: invitation token service and table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ PORT_MAILPIT=8025
 
 # Frontend
 VITE_API_BASE=http://localhost:8000
+
+# Invitations
+INVITES_SECRET=dev-secret
+INVITES_TTL_SECONDS=604800

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pwsh -NoLogo -NoProfile -File PS1/repro_storybook_ci_cache.ps1
 
 ## Envs requis
 
-Voir .env.example. Pas de secrets dans le repo.
+Voir .env.example. Pas de secrets dans le repo. Ajout de `INVITES_SECRET` et `INVITES_TTL_SECONDS` pour les tokens d'invitation.
 
 ## Ports
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -225,3 +225,19 @@ scrape_configs:
 $Env:PYTHONPATH="backend"
 backend\.venv\Scripts\python -m pytest -q -k "obs or readiness or metrics"
 ```
+
+## Invitations (Jalon 15.5)
+
+Tokens signes pour l'acceptation des assignments.
+
+### Variables env
+
+* `INVITES_SECRET`
+* `INVITES_TTL_SECONDS` (defaut 604800)
+
+### Tests
+
+```powershell
+$Env:PYTHONPATH="backend"
+backend\.venv\Scripts\python -m pytest -q backend/tests/test_invitations_tokens.py
+```

--- a/backend/alembic/versions/0005_invitations_table.py
+++ b/backend/alembic/versions/0005_invitations_table.py
@@ -1,0 +1,36 @@
+"""Jalon 15.5 invitations table"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0005_invitations_table"
+down_revision = "0004_rbac_org_memberships"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invitations",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("assignment_id", sa.String(length=36), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["assignment_id"], ["assignments.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_invitations_token_hash", "invitations", ["token_hash"], unique=False)
+    op.create_index("ix_invitations_expires_at", "invitations", ["expires_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_invitations_token_hash", table_name="invitations")
+    op.drop_index("ix_invitations_expires_at", table_name="invitations")
+    op.drop_table("invitations")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,6 +26,8 @@ class Settings(BaseSettings):
     SECRET_KEY: str = "changeme"
     ACCESS_TOKEN_EXPIRES_MIN: int = 15
     REFRESH_TOKEN_EXPIRES_MIN: int = 7 * 24 * 60
+    INVITES_SECRET: str = "change-me"
+    INVITES_TTL_SECONDS: int = 604800
 
     model_config = SettingsConfigDict(
         env_file=None,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -175,16 +175,22 @@ class Availability(Base, TSMixin):
     )
 
 
-class Invitation(Base, TSMixin):
+class Invitation(Base):
     __tablename__ = "invitations"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
-    org_id: Mapped[str] = mapped_column(String(36), ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
-    mission_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("missions.id", ondelete="SET NULL"))
-    user_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("users.id", ondelete="SET NULL"))
-    token: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
-    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
-    revoked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    assignment_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("assignments.id", ondelete="CASCADE"), nullable=False
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.utcnow(), nullable=False)
+
+    __table_args__ = (
+        Index("ix_invitations_token_hash", "token_hash"),
+        Index("ix_invitations_expires_at", "expires_at"),
+    )
 
 
 class AuditLog(Base):

--- a/backend/app/services/invitations.py
+++ b/backend/app/services/invitations.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from ..core.config import settings
+from ..models import Invitation
+from .tokens import sign_invite_token, verify_invite_token
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def create_invitation(db: Session, assignment_id: str) -> tuple[Invitation, str]:
+    token, token_hash = sign_invite_token(assignment_id)
+    expires = _now() + timedelta(seconds=settings.INVITES_TTL_SECONDS)
+    inv = Invitation(
+        assignment_id=assignment_id,
+        token_hash=token_hash,
+        expires_at=expires,
+        created_at=_now(),
+    )
+    db.add(inv)
+    db.commit()
+    db.refresh(inv)
+    return inv, token
+
+
+def revoke_invitation(db: Session, invitation: Invitation) -> None:
+    invitation.revoked_at = _now()
+    db.add(invitation)
+    db.commit()
+
+
+def get_invitation_by_token(db: Session, token: str) -> Optional[Invitation]:
+    try:
+        data = verify_invite_token(token)
+    except Exception:
+        return None
+    token_hash = data.get("jti")
+    if token_hash is None:
+        return None
+    token_hash = hashlib.sha256(token_hash.encode()).hexdigest()
+    return db.query(Invitation).filter_by(token_hash=token_hash).first()

--- a/backend/app/services/tokens.py
+++ b/backend/app/services/tokens.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+
+import jwt
+
+from ..core.config import settings
+
+
+_DEF_ALGO = "HS256"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def sign_invite_token(assignment_id: str) -> tuple[str, str]:
+    """Sign a token for an assignment.
+
+    Returns the token and the sha256 hash of the jti for storage.
+    """
+    jti = str(uuid.uuid4())
+    exp = _now() + timedelta(seconds=settings.INVITES_TTL_SECONDS)
+    payload = {"sub": assignment_id, "jti": jti, "exp": exp}
+    token = jwt.encode(payload, settings.INVITES_SECRET, algorithm=_DEF_ALGO)
+    token_hash = hashlib.sha256(jti.encode()).hexdigest()
+    return token, token_hash
+
+
+def verify_invite_token(token: str) -> Dict[str, Any]:
+    """Verify token signature and expiration."""
+    return jwt.decode(token, settings.INVITES_SECRET, algorithms=[_DEF_ALGO])

--- a/backend/tests/test_invitations_tokens.py
+++ b/backend/tests/test_invitations_tokens.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+
+from app.services.tokens import sign_invite_token, verify_invite_token
+
+
+def test_sign_and_verify():
+    token, h = sign_invite_token("a1")
+    assert isinstance(token, str)
+    assert len(h) == 64
+    data = verify_invite_token(token)
+    assert data["sub"] == "a1"
+
+
+def test_expired_token(monkeypatch):
+    monkeypatch.setattr("app.services.tokens.settings.INVITES_TTL_SECONDS", 1)
+    token, _ = sign_invite_token("a2")
+    time.sleep(2)
+    with pytest.raises(jwt.ExpiredSignatureError):
+        verify_invite_token(token)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,3 +10,7 @@
 - HTTP client avec retries et CSRF.
 - Gestion d'état avec TanStack Query et Zustand.
 - Update optimiste et route /dev/retry pour tests.
+
+## Jalon 15.5 – Workflow acceptation mission
+- Service de tokens d'invitation (HMAC, expiration).
+- Table `invitations` avec hash de token.

--- a/docs/flows/acceptance_sequence.txt
+++ b/docs/flows/acceptance_sequence.txt
@@ -1,0 +1,4 @@
+Manager -> POST /v1/invitations -> token signe
+User (email/lien) -> GET /invite/:code -> POST accept/decline
+API -> verif token+expiry -> update assignments.status -> audit log
+FE -> invalidate queries -> planning UI/counters MAJ


### PR DESCRIPTION
## Summary
- add environment variables and config for invitation tokens
- create invitation token service and model with migration
- document acceptance sequence and provide basic token tests

## Testing
- `PYTHONPATH=backend pytest -q backend/tests/test_invitations_tokens.py`


------
https://chatgpt.com/codex/tasks/task_e_68b486f10e9483309767beeab252182e