### PR TITLE
fix: align alembic db url and idempotent migration

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,58 +1,69 @@
-from __future__ import annotations
-import os
 from logging.config import fileConfig
-
-from sqlalchemy import engine_from_config, pool
+import os
+from sqlalchemy import engine_from_config, pool, create_engine
+from sqlalchemy.pool import StaticPool
 from alembic import context
 
-# Config Alembic
 
 config = context.config
-
-# Logging config
-
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# URL prioritaire: env DATABASE_URL sinon valeur d env alembic DB_URL sinon fallback SQLite
-
-db_url = os.getenv("DATABASE_URL") or os.getenv("DB_URL") or "sqlite:///./backend/dev.db"
-config.set_main_option("sqlalchemy.url", db_url)
-
-# Pas d autogenerate au jalon 2 (schema min gere via operations scripts)
-
 target_metadata = None
 
+
 def run_migrations_offline() -> None:
-    url = config.get_main_option("sqlalchemy.url")
+    url = (
+        os.getenv("ALEMBIC_URL")
+        or os.getenv("DATABASE_URL")
+        or config.get_main_option("sqlalchemy.url")
+    )
+    if url:
+        config.set_main_option("sqlalchemy.url", url)
     context.configure(
         url=url,
+        target_metadata=target_metadata,
         literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
     )
     with context.begin_transaction():
         context.run_migrations()
 
+
 def run_migrations_online() -> None:
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-        future=True,
+    url = (
+        os.getenv("ALEMBIC_URL")
+        or os.getenv("DATABASE_URL")
+        or config.get_main_option("sqlalchemy.url")
     )
-    try:
-        with connectable.connect() as connection:
-            context.configure(connection=connection)
-            with context.begin_transaction():
-                context.run_migrations()
-    finally:
-        # Important sous Windows/SQLite: libere les poignees de fichiers
-        try:
-            connectable.dispose()
-        except Exception:
-            # Pas bloquant: on evite d echouer le pipeline si la disposal echoue
-            pass
+    if url:
+        config.set_main_option("sqlalchemy.url", url)
+
+    if url and url.startswith("sqlite") and (
+        ":memory:" in url or "mode=memory" in url
+    ):
+        connectable = create_engine(
+            url,
+            future=True,
+            poolclass=StaticPool,
+            connect_args={"check_same_thread": False},
+        )
+    else:
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+            future=True,
+        )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
 
 if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
+

--- a/backend/alembic/versions/0005_invitations_table.py
+++ b/backend/alembic/versions/0005_invitations_table.py
@@ -13,8 +13,7 @@ depends_on = None
 
 def upgrade() -> None:
     bind = op.get_bind()
-    insp = inspect(bind)
-    if "invitations" in insp.get_table_names():
+    if "invitations" in inspect(bind).get_table_names():
         return
 
     op.create_table(
@@ -38,10 +37,5 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     bind = op.get_bind()
-    insp = inspect(bind)
-    if "invitations" not in insp.get_table_names():
-        return
-
-    op.drop_index("ix_invitations_token_hash", table_name="invitations")
-    op.drop_index("ix_invitations_expires_at", table_name="invitations")
-    op.drop_table("invitations")
+    if "invitations" in inspect(bind).get_table_names():
+        op.drop_table("invitations")

--- a/backend/tests/test_assignments_uniqueness.py
+++ b/backend/tests/test_assignments_uniqueness.py
@@ -37,6 +37,7 @@ def teardown_module(module) -> None:  # noqa: ANN001
 
 def _alembic_upgrade(url: str) -> None:
     os.environ["DB_URL"] = url
+    os.environ["DATABASE_URL"] = url
     cfg = Config("backend/alembic.ini")
     cfg.set_main_option("script_location", "backend/alembic")
     command.upgrade(cfg, "head")


### PR DESCRIPTION
## Summary
- unify Alembic config to read DB URL from `ALEMBIC_URL`/`DATABASE_URL` and share in-memory SQLite engines
- make invitations migration idempotent
- ensure assignment uniqueness test sets `DATABASE_URL`

## Testing
- `python -m pytest backend/tests/test_assignments_uniqueness.py::test_unique_active_assignment_ok_and_ko -q --disable-warnings --maxfail=1`
- `python -m pytest backend/tests/test_cache.py::test_projects_cache_hit_miss_and_invalidation -q --disable-warnings --maxfail=1` *(fails: no such table: accounts)*


------
https://chatgpt.com/codex/tasks/task_e_68b48c22ee9483308189ba79166d8fd2