### PR TITLE
fix: avoid double drop of invitations table

### DIFF
--- a/backend/alembic/versions/0002_models_core.py
+++ b/backend/alembic/versions/0002_models_core.py
@@ -177,7 +177,8 @@ def downgrade() -> None:
     op.drop_table("audit_log")
     op.drop_table("user_tags")
     op.drop_table("user_skills")
-    op.drop_table("invitations")
+    # NOTE: 'invitations' est gérée par 0005_invitations_table (upgrade + downgrade).
+    # Ne PAS la supprimer ici.
     op.drop_index("ix_availability_ends_at", table_name="availability")
     op.drop_index("ix_availability_starts_at", table_name="availability")
     op.drop_table("availability")


### PR DESCRIPTION
## Summary
- don't drop invitations table in 0002 downgrade

## Testing
- `python -m ruff check backend`
- `python -m mypy --config-file backend/mypy.ini backend`
- `python -m pytest -q --disable-warnings --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b492e7ffd083308fb54fb6850853d7