### PR TITLE
Fix mypy duplicate module + editable build

### DIFF
--- a/PS1/mypy.ps1
+++ b/PS1/mypy.ps1
@@ -1,0 +1,6 @@
+Param()
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version Latest
+$python = if (Test-Path "backend.venv\Scripts\python.exe") { "backend.venv\Scripts\python" } else { "python" }
+& $python -m mypy --config-file mypy.ini
+

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ pwsh -NoLogo -NoProfile -File PS1/repro_storybook_ci_cache.ps1
 * PS1/dev_down.ps1 : arrete le stack compose (option -Prune pour volumes)
 * PS1/smoke.ps1 : verif /healthz, /metrics et endpoint invitation
 * PS1/test_all.ps1 : ruff, mypy, pytest, npm lint
+* PS1/mypy.ps1 : lance mypy avec mypy.ini (evite le doublon app/backend.app)
 * PS1/test_backend.ps1 : tests unitaires conflits
 * PS1/e2e_conflicts.ps1 : e2e Playwright (conflits)
 * PS1/fe_test.ps1 : npm lint, typecheck, unit
@@ -129,7 +130,7 @@ Si un `.npmrc` global force une registry privee, ce pin l ignore.
 
 ```powershell
 backend\.venv\Scripts\python -m ruff check backend
-backend\.venv\Scripts\python -m mypy --config-file backend\mypy.ini backend
+backend\.venv\Scripts\python -m mypy --config-file mypy.ini
 $Env$Env:PYTHONPATH="backend"; backend\.venv\Scripts\python -m pytest -q -k "v1_endpoints"
 ```
 ### Typing (passlib)
@@ -137,7 +138,7 @@ $Env$Env:PYTHONPATH="backend"; backend\.venv\Scripts\python -m pytest -q -k "v1_
 passlib n a pas de stubs officiels. Nous:
 
 * ignorons l import dans `backend/app/auth.py` via `# type: ignore[import-untyped]`
-* desactivons `import-untyped` uniquement pour `passlib.*` dans `backend/mypy.ini`
+* desactivons `import-untyped` uniquement pour `passlib.*` dans `mypy.ini`
 
 ## Warnings CI
 
@@ -152,7 +153,7 @@ TESTS (PS + curl):
 * Windows:
 
   * backend.venv\Scripts\python -m ruff check backend
-  * backend.venv\Scripts\python -m mypy --config-file backend\mypy.ini backend
+  * backend.venv\Scripts\python -m mypy --config-file mypy.ini
   * $Env:PYTHONPATH="backend"; backend.venv\Scripts\python -m pytest -q
   * pwsh -NoLogo -NoProfile -File PS1/fe_test.ps1
   * pwsh -NoLogo -NoProfile -File PS1/fe_e2e.ps1

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,14 @@
 # Backend Coulisses Crew
 
+### Installation editable (dev)
+
+```
+python -m pip install -U pip
+pip install -e .
+```
+
+Le packaging est limite au package `app` (Alembic exclu). Typage: `mypy.ini` pointe sur `backend` comme package racine.
+
 ## Jalon 1 - Backend skeleton + healthz
 
 * GET /healthz -> 200 JSON {"status":"ok"}

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,2 @@
+# Marque 'backend' comme package pour eviter la double resolution mypy.
+

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,3 +1,20 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "orga-backend"
+version = "0.0.0"
+requires-python = ">=3.10"
+
+[tool.setuptools]
+# Decouverte controlee: inclure uniquement 'app' (et sous-packages)
+packages = ["app"]
+
+[tool.setuptools.package-data]
+# alembic\* lu au runtime, pas distribue comme package python
+app = ["py.typed"]
+
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["backend/tests"]
@@ -10,7 +27,7 @@ line-length = 100
 target-version = "py310"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_unused_ignores = true
 warn_redundant_casts = true
 strict = true

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -245,6 +245,7 @@ Tests: tests conflits backend + e2e resolution.
 CI Gates: e2e conflits.
 Docs: algos et limites.
 Acceptance: conflit resolu via UI.
+Note packaging/typing: ajouter backend/__init__.py ; mypy.ini avec explicit_package_bases ; setuptools limite a 'app'.
 
 ## Jalon 18 - Notifications (email + Telegram) fonctionnelles
 But: envoi reel + liens d acceptation securises + centre de notifications.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,20 @@
+[mypy]
+python_version = 3.12
+explicit_package_bases = True
+mypy_path = backend
+files = backend
+exclude = backend/tests
+
+# Evite la double cartographie app.* vs backend.app.*
+# On type-check uniquement le package 'backend' (qui contient 'app').
+
+[mypy-passlib.*]
+ignore_missing_imports = True
+disable_error_code = import-untyped
+
+[mypy-jwt.*]
+ignore_missing_imports = True
+
+[mypy-fakeredis.*]
+ignore_missing_imports = True
+


### PR DESCRIPTION
## Summary
- mark backend as a package and provide global mypy config with explicit package bases
- restrict setuptools discovery to only the `app` package and add py.typed data
- document editable installs and add PowerShell helper for mypy

## Testing
- `python -m ruff check backend`
- `python -m mypy --config-file mypy.ini`
- `PYTHONPATH=backend python -m pytest -q backend/tests/test_conflicts_service_ok.py backend/tests/test_conflicts_service_ko.py`
- `curl "http://localhost:8000/api/v1/conflicts?from=2025-09-01T00:00:00Z&to=2025-09-30T00:00:00Z"` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aee9ed808330a745233f430ee94c