### PR TITLE
Fix mypy path (app, tests.utils)

### DIFF
--- a/PS1/mypy.ps1
+++ b/PS1/mypy.ps1
@@ -1,6 +1,8 @@
 Param()
 $ErrorActionPreference="Stop"
 Set-StrictMode -Version Latest
+
+# Force le chemin de recherche pour mypy
+$env:MYPYPATH = "backend"
 $python = if (Test-Path "backend.venv\Scripts\python.exe") { "backend.venv\Scripts\python" } else { "python" }
 & $python -m mypy --config-file mypy.ini
-

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ pwsh -NoLogo -NoProfile -File PS1/repro_storybook_ci_cache.ps1
 * PS1/dev_down.ps1 : arrete le stack compose (option -Prune pour volumes)
 * PS1/smoke.ps1 : verif /healthz, /metrics et endpoint invitation
 * PS1/test_all.ps1 : ruff, mypy, pytest, npm lint
-* PS1/mypy.ps1 : lance mypy avec mypy.ini (evite le doublon app/backend.app)
-* PS1/test_backend.ps1 : tests unitaires conflits
+* PS1/mypy.ps1 : lance mypy avec `MYPYPATH=backend` et `mypy.ini`
+* PS1/test_backend.ps1 : tests unitaires backend
 * PS1/e2e_conflicts.ps1 : e2e Playwright (conflits)
 * PS1/fe_test.ps1 : npm lint, typecheck, unit
 * PS1/fe_e2e.ps1 : build + e2e smoke

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,7 +7,16 @@ python -m pip install -U pip
 pip install -e .
 ```
 
-Le packaging est limite au package `app` (Alembic exclu). Typage: `mypy.ini` pointe sur `backend` comme package racine.
+Le packaging est limite au package `app` (Alembic exclu).
+
+## Typing (mypy)
+
+* Chemin de recherche configure: `mypy_path=backend` pour resoudre `app.*` et `tests.*`.
+* Commande:
+
+```
+pwsh -NoLogo -NoProfile -File ..\PS1\mypy.ps1
+```
 
 ## Jalon 1 - Backend skeleton + healthz
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,2 +1,2 @@
-# Marque 'backend' comme package pour eviter la double resolution mypy.
+# Marque 'backend' comme package racine pour les outils.
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,12 @@
-"""Application package."""
+# Package app (py.typed pour mypy/peps)
+
+# fichier volontairement minimal
+
+__all__: list[str] = []
+
+# Indiquer a mypy que le package est type-hinte (si vous avez un fichier py.typed, gardez-le)
+try:
+    import importlib.resources as _res  # noqa: F401
+except Exception:
+    pass
+

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+# Rend 'tests' importable (ex: from tests.utils import ...)

--- a/backend/tests/test_conflicts_service_ko.py
+++ b/backend/tests/test_conflicts_service_ko.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from backend.app.services.conflicts import ConflictService
+from app.services.conflicts import ConflictService
 
 
 class MockEmpty:

--- a/backend/tests/test_conflicts_service_ok.py
+++ b/backend/tests/test_conflicts_service_ok.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from backend.app.services.conflicts import ConflictService, Assignment
+from app.services.conflicts import ConflictService, Assignment
 
 
 class MockDB:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,8 @@
 
 > Source de verite. A LIRE avant toute PR. ASCII uniquement. Windows-first. Zero secret dans le repo et les workflows.
 
+J17: Typing stabilise: `mypy_path=backend`, ajout `backend/tests/__init__.py`, `backend/app/__init__.py`. Runner PowerShell `.\\PS1\\mypy.ps1`.
+
 ## Objectifs
 - Livrer un MVP fiable (backend + frontend) puis durcir la securite a la fin.
 - CI verte a chaque jalon, petites etapes atomiques pour eviter la casse.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,12 +1,21 @@
 [mypy]
 python_version = 3.12
-explicit_package_bases = True
-mypy_path = backend
-files = backend
-exclude = backend/tests
 
-# Evite la double cartographie app.* vs backend.app.*
-# On type-check uniquement le package 'backend' (qui contient 'app').
+# Important: limite la decouverte aux dossiers sous backend/
+packages = app, tests
+
+# Chemin de recherche pour les imports 'app' et 'tests'
+mypy_path = backend
+explicit_package_bases = True
+namespace_packages = True
+ignore_missing_imports = False
+show_error_codes = True
+pretty = True
+
+# Optionnel: regler la verbosite sur tests si besoin
+
+[mypy-backend.tests.*]
+ignore_errors = False
 
 [mypy-passlib.*]
 ignore_missing_imports = True
@@ -17,4 +26,3 @@ ignore_missing_imports = True
 
 [mypy-fakeredis.*]
 ignore_missing_imports = True
-


### PR DESCRIPTION
## Summary
- configure mypy to resolve `app.*` and `tests.*` via `mypy_path=backend`
- add package initializers for `backend`, `app`, and `tests`
- add PowerShell runner for mypy and document new typing workflow

## Testing
- `backend.venv/Scripts/python -m ruff check backend`
- `MYPYPATH=backend backend.venv/Scripts/python -m mypy --config-file mypy.ini`
- `PYTHONPATH=backend backend.venv/Scripts/python -m pytest -q backend/tests/test_conflicts_service_ok.py backend/tests/test_conflicts_service_ko.py`

Labels: tests, docs-required

------
https://chatgpt.com/codex/tasks/task_e_68b4b2184f1c8330ad608602a25843c3