### PR TITLE
CI: mypy avec MYPYPATH=backend

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,31 @@
+name: lint-python
+on:
+  pull_request:
+    paths:
+    - "backend/**"
+    - ".github/workflows/lint-python.yml"
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install tools
+      run: |
+        python -m pip install -U pip
+        python -m pip install mypy ruff
+    - name: Ruff
+      run: |
+        python -m ruff check backend
+    - name: Mypy (with config + path)
+      env:
+        MYPYPATH: backend
+      run: |
+        # Lancer depuis la racine pour que mypy.ini soit pris en compte
+        python -m mypy --config-file mypy.ini

--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ pwsh -NoLogo -NoProfile -File .\PS1\mypy.ps1
 - obs-smoke: tests ciblant observabilite (/metrics, probes)
   Relire `docs/ROADMAP.md` avant toute PR.
 
+## CI Typage (mypy)
+
+La CI force `MYPYPATH=backend` et utilise `mypy.ini` du repo pour resoudre `app.*` et `tests.*`.
+Local:
+
+```powershell
+pwsh -NoLogo -NoProfile -File .\PS1\mypy.ps1
+```
+
 ### Repro locale (Windows)
 
 ```powershell

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Source de verite. A LIRE avant toute PR. ASCII uniquement. Windows-first. Zero secret dans le repo et les workflows.
 
-* J17: Stabilisation mypy: `mypy_path=backend`, ajout `backend/tests/__init__.py`, `backend/app/__init__.py`, script `.\\PS1\\mypy.ps1`.
+* J17: CI mypy stabilisee: etape mypy appelle `python -m mypy --config-file mypy.ini` avec `MYPYPATH=backend`.
 
 ## Objectifs
 - Livrer un MVP fiable (backend + frontend) puis durcir la securite a la fin.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,23 +1,22 @@
 [mypy]
 python_version = 3.12
 
-# On limite l analyse a notre code dans backend/
-
+# Analyser tout le dossier backend (code + tests)
 files = backend
 
-# Cle: indique a mypy ou trouver les modules 'app' et 'tests'
-
+# Chemin de recherche pour les imports top-level 'app' et 'tests'
 mypy_path = backend
 explicit_package_bases = True
 namespace_packages = True
-show_error_codes = True
 pretty = True
+show_error_codes = True
 warn_unused_ignores = True
 warn_redundant_casts = True
 no_implicit_optional = True
 
-# Autoriser les tests a importer 'tests.utils'
-
-[mypy-tests.*]
+[mypy-backend.tests.*]
 ignore_errors = False
 
+# (Optionnel) si certains modules tiers manquent de stubs:
+#[mypy-someexternal.*]
+#ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- enforce mypy config path via new lint-python workflow
- document CI mypy path and usage

## Testing
- `backend.venv\Scripts\python -m ruff check backend` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File .\PS1\mypy.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File .\PS1\test_backend.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b865ced083308c0dad5fc102c817