### PR TITLE
Fix mypy: packages app/tests + ignore deps tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ pwsh -NoLogo -NoProfile -Command "backend\.venv\Scripts\python -m ruff check bac
 pwsh -NoLogo -NoProfile -File .\PS1\mypy.ps1
 ```
 
+Notes:
+
+* Le package `app` est declare avec `__init__.py` et `py.typed`.
+* Les libs tiers sans stubs (fastapi, sqlalchemy, etc.) sont ignorees cote mypy; notre code `app.*` et `tests.*` reste strict.
+
+
 ### Jalon 15.5 — Workflow d’acceptation mission
 - API: /v1/invitations (create/revoke/verify), /v1/assignments/{id}/accept|decline (token ou session)
 - UI: My Missions, Invite Landing (/invite?token=...)

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,10 +9,11 @@ pip install -e .
 
 Le packaging est limite au package `app` (Alembic exclu).
 
-### Typage (mypy)
+## Typage (mypy)
 
-* La config `mypy.ini` au root fixe `mypy_path=backend`.
-* Execution:
+* Chemins: `MYPYPATH=backend`, `files=backend`.
+* Packages declares: `app` (py.typed), `tests`.
+* Commande:
 
 ```powershell
 pwsh -NoLogo -NoProfile -File ..\PS1\mypy.ps1

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,3 @@
-# Package 'app'
+# Package 'app' explicite
 
 __all__: list[str] = []
-

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,3 +1,5 @@
+# Sous-package api
+
 from __future__ import annotations
 
 from fastapi import APIRouter
@@ -8,3 +10,6 @@ router = APIRouter(prefix="/api/v1")
 @router.get("/ping")
 def ping() -> dict[str, str]:
     return {"status": "ok"}
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,0 +1,3 @@
+# Sous-package api.v1
+
+__all__: list[str] = []

--- a/backend/app/py.typed
+++ b/backend/app/py.typed
@@ -1,0 +1,3 @@
+# Fichier indicateur pour PEP 561 (package typed)
+
+# (la presence suffit; contenu vide)

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,3 @@
+# Sous-package services
+
+__all__: list[str] = []

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,1 +1,3 @@
-# Package 'tests' pour permettre 'from tests.utils import ...'
+# Package 'tests' pour autoriser 'from tests.utils import ...'
+
+__all__: list[str] = []

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,6 +3,11 @@
 > Source de verite. A LIRE avant toute PR. ASCII uniquement. Windows-first. Zero secret dans le repo et les workflows.
 
 * J17: CI mypy stabilisee: etape mypy appelle `python -m mypy --config-file mypy.ini` avec `MYPYPATH=backend`.
+* J17: Stabilisation mypy imports:
+  - Ajout `__init__.py` (app/, services/, api/, api/v1/, tests/)
+  - Ajout `app/py.typed`
+  - mypy.ini: ignore imports tiers sans stubs; enforcement strict pour app/tests.
+
 
 ## Objectifs
 - Livrer un MVP fiable (backend + frontend) puis durcir la securite a la fin.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,6 @@
 [mypy]
 python_version = 3.12
-
-# Analyser tout le dossier backend (code + tests)
 files = backend
-
-# Chemin de recherche pour les imports top-level 'app' et 'tests'
 mypy_path = backend
 explicit_package_bases = True
 namespace_packages = True
@@ -14,9 +10,37 @@ warn_unused_ignores = True
 warn_redundant_casts = True
 no_implicit_optional = True
 
-[mypy-backend.tests.*]
-ignore_errors = False
+# Notre code doit etre strict: pas d ignore_missing_imports pour app/tests
 
-# (Optionnel) si certains modules tiers manquent de stubs:
-#[mypy-someexternal.*]
-#ignore_missing_imports = True
+[mypy-app.*]
+ignore_missing_imports = False
+
+[mypy-tests.*]
+ignore_missing_imports = False
+
+# Libs tiers sans stubs: on ignore uniquement leurs imports
+
+[mypy-fastapi.*]
+ignore_missing_imports = True
+[mypy-starlette.*]
+ignore_missing_imports = True
+[mypy-pydantic.*]
+ignore_missing_imports = True
+[mypy-pydantic_settings.*]
+ignore_missing_imports = True
+[mypy-sqlalchemy.*]
+ignore_missing_imports = True
+[mypy-alembic.*]
+ignore_missing_imports = True
+[mypy-redis.*]
+ignore_missing_imports = True
+[mypy-fakeredis.*]
+ignore_missing_imports = True
+[mypy-prometheus_client.*]
+ignore_missing_imports = True
+[mypy-jwt.*]
+ignore_missing_imports = True
+[mypy-pytest.*]
+ignore_missing_imports = True
+[mypy-uvicorn.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- add explicit package markers for app, services, api and tests
- ship py.typed and tighten mypy config while ignoring untyped deps
- document typing workflow in READMEs and roadmap

## Testing
- `python -m ruff check backend`
- `pwsh -NoLogo -NoProfile -File ./PS1/mypy.ps1`
- `pwsh -NoLogo -NoProfile -File ./PS1/test_backend.ps1` *(fails: backend\tests\test_conflicts_service_ok.py not found, paths use Windows separators)*
- `python -m pytest -q backend/tests/test_conflicts_service_ok.py backend/tests/test_conflicts_service_ko.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb244f948330a9155d43b54b4e5b