### PR TITLE
J17 Fix: mypy cwd backend + remove unused-ignore

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Ruff
       run: |
         python -m ruff check backend
-    - name: Mypy (with config + path)
-      env:
-        MYPYPATH: backend/typings:backend
+    - name: Mypy (cwd backend)
+      working-directory: backend
       run: |
-        python -m mypy --config-file mypy.ini
+        python -m mypy --version
+        python -m mypy --config-file ../mypy.ini app tests

--- a/PS1/mypy_backend.ps1
+++ b/PS1/mypy_backend.ps1
@@ -1,0 +1,15 @@
+Param()
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version Latest
+
+# Choix python
+
+$python = if (Test-Path "backend.venv\Scripts\python.exe") { "backend.venv\Scripts\python" } else { "python" }
+
+# Lancer mypy depuis backend pour resoudre 'app' et 'tests'
+
+pushd backend
+& $python -m mypy --config-file ../mypy.ini app tests
+$code = $LASTEXITCODE
+popd
+if ($code -ne 0) { exit $code }

--- a/README.md
+++ b/README.md
@@ -31,13 +31,16 @@ pwsh -NoLogo -NoProfile -Command "backend\.venv\Scripts\python -m ruff check bac
 
 ## Typage (mypy)
 
-* Portee analyse: `backend/app, backend/tests` (les stubs locaux ne sont pas scannes).
-* Recherche modules: `backend/typings:backend` (CI Linux). Le script PS ajuste automatiquement pour Windows.
-* Commandes:
+Local (Windows-first):
 
 ```powershell
-pwsh -NoLogo -NoProfile -File .\PS1\mypy.ps1
+pwsh -NoLogo -NoProfile -File .\PS1\mypy_backend.ps1
 ```
+
+CI:
+
+* Etape mypy lance dans `working-directory: backend` avec:
+  `python -m mypy --config-file ../mypy.ini app tests`
 
 ### Jalon 15.5 — Workflow d’acceptation mission
 - API: /v1/invitations (create/revoke/verify), /v1/assignments/{id}/accept|decline (token ou session)
@@ -68,11 +71,16 @@ pwsh -NoLogo -NoProfile -File .\PS1\mypy.ps1
 
 ## CI Typage (mypy)
 
-La CI force `MYPYPATH=backend` et utilise `mypy.ini` du repo pour resoudre `app.*` et `tests.*`.
+La CI execute mypy depuis `backend/`:
+
+```bash
+python -m mypy --config-file ../mypy.ini app tests
+```
+
 Local:
 
 ```powershell
-pwsh -NoLogo -NoProfile -File .\PS1\mypy.ps1
+pwsh -NoLogo -NoProfile -File .\PS1\mypy_backend.ps1
 ```
 
 ### Repro locale (Windows)
@@ -88,7 +96,7 @@ pwsh -NoLogo -NoProfile -File PS1/repro_storybook_ci_cache.ps1
 * PS1/dev_down.ps1 : arrete le stack compose (option -Prune pour volumes)
 * PS1/smoke.ps1 : verif /healthz, /metrics et endpoint invitation
 * PS1/test_all.ps1 : ruff, mypy, pytest, npm lint
-* PS1/mypy.ps1 : lance mypy avec `MYPYPATH=backend` et `mypy.ini`
+* PS1/mypy_backend.ps1 : lance mypy depuis `backend/`
 * PS1/test_backend.ps1 : tests unitaires backend
 * PS1/e2e_conflicts.ps1 : e2e Playwright (conflits)
 * PS1/fe_test.ps1 : npm lint, typecheck, unit

--- a/backend/README.md
+++ b/backend/README.md
@@ -11,9 +11,17 @@ Le packaging est limite au package `app` (Alembic exclu).
 
 ### Mypy
 
-* `mypy_path` colon-separe dans `mypy.ini` pour CI Linux.
-* Local Windows: le script PS utilise le separateur adequat.
-* Les stubs locaux (`backend/typings`) ne sont pas inclus dans `files`.
+Executez depuis backend:
+
+```
+python -m mypy --config-file ../mypy.ini app tests
+```
+
+ou
+
+```
+pwsh -NoLogo -NoProfile -File ..\PS1\mypy_backend.ps1
+```
 
 ## Jalon 1 - Backend skeleton + healthz
 

--- a/backend/app/api_v1_projects.py
+++ b/backend/app/api_v1_projects.py
@@ -89,7 +89,8 @@ def delete_project(pid: str, current=Depends(require_role(Role.admin)), db: Sess
     org_id = current["org_id"]
     res = db.execute(text("DELETE FROM projects WHERE id=:p AND org_id=:o"), {"p": pid, "o": org_id})
     db.commit()
-    if res.rowcount == 0:  # type: ignore[attr-defined]
+    rowcount = getattr(res, "rowcount", 0)
+    if (rowcount or 0) == 0:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="project introuvable")
     get_cache().invalidate_tags([f"projects:{org_id}"])
     return {"status": "ok"}

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -79,8 +79,8 @@ def get_db() -> Session:
     return SessionLocal()
 
 def get_current_account(
+    request: Request,
     creds: Optional[HTTPAuthorizationCredentials] = Depends(bearer_scheme),
-    request: Request = None,  # type: ignore[assignment]
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     if not creds:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,4 @@
-J17: mypy stabilise
-
-* Eviter doublon stubs: `files=backend/app,backend/tests` + `mypy_path=backend/typings:backend`
-* PS cross-OS pour MYPYPATH
-* `__all__` type-annotes
+J17: mypy stabilise par cwd=backend; suppression des `# type: ignore` inutiles dans `auth.py` et `api_v1_projects.py`.
 
 ## Objectifs
 - Livrer un MVP fiable (backend + frontend) puis durcir la securite a la fin.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,32 +1,23 @@
 [mypy]
 python_version = 3.12
 
-# IMPORTANT: n analyse que notre code, pas les stubs locaux
+# On appelle mypy en cwd=backend avec "app tests", donc pas besoin de mypy_path
 
-files = backend/app, backend/tests
-
-# Chemins de recherche pour les modules top-level.
-
-# NOTE: le separateur dans ce fichier doit etre ':' (CI Linux)
-
-mypy_path = backend/typings:backend
-
-explicit_package_bases = True
-namespace_packages = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+no_implicit_optional = True
 pretty = True
 show_error_codes = True
-no_implicit_optional = True
-warn_redundant_casts = True
-warn_unused_ignores = True
+explicit_package_bases = True
 
-# Notre code reste strict
+# Notre code strict
 
 [mypy-app.*]
 ignore_missing_imports = False
 [mypy-tests.*]
 ignore_missing_imports = False
 
-# Libs tiers sans stubs: ignore uniquement leurs imports
+# Libs tiers (pas de stubs)
 
 [mypy-fastapi.*]
 ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- drop unused `type: ignore` and handle delete rowcount safely
- add `mypy_backend.ps1` script and call mypy from backend
- document updated mypy usage and configuration

## Testing
- `python -m ruff check backend`
- `pwsh -NoLogo -NoProfile -File PS1/mypy_backend.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/test_backend.ps1` *(fails: file or directory not found: backend\tests\test_conflicts_service_ok.py)*
- `python -m pytest -q` *(fails: assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c833e3ec8330b3ff8656e87cc796