### PR TITLE
Fix: mypy unused-ignore + run from backend

### DIFF
--- a/PS1/mypy_backend.ps1
+++ b/PS1/mypy_backend.ps1
@@ -1,13 +1,7 @@
 Param()
 $ErrorActionPreference="Stop"
 Set-StrictMode -Version Latest
-
-# Choix python
-
 $python = if (Test-Path "backend.venv\Scripts\python.exe") { "backend.venv\Scripts\python" } else { "python" }
-
-# Lancer mypy depuis backend pour resoudre 'app' et 'tests'
-
 pushd backend
 & $python -m mypy --config-file ../mypy.ini app tests
 $code = $LASTEXITCODE

--- a/README.md
+++ b/README.md
@@ -165,15 +165,14 @@ Si un `.npmrc` global force une registry privee, ce pin l ignore.
 
 ```powershell
 backend\.venv\Scripts\python -m ruff check backend
-backend\.venv\Scripts\python -m mypy --config-file mypy.ini
-$Env$Env:PYTHONPATH="backend"; backend\.venv\Scripts\python -m pytest -q -k "v1_endpoints"
+pwsh -NoLogo -NoProfile -File PS1/mypy_backend.ps1
+$Env:PYTHONPATH="backend"; backend\.venv\Scripts\python -m pytest -q -k "v1_endpoints"
 ```
 ### Typing (passlib)
 
 passlib n a pas de stubs officiels. Nous:
 
-* ignorons l import dans `backend/app/auth.py` via `# type: ignore[import-untyped]`
-* desactivons `import-untyped` uniquement pour `passlib.*` dans `mypy.ini`
+* ignorons l import dans `backend/app/auth.py` via `# type: ignore[import-untyped]`.
 
 ## Warnings CI
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,15 +9,13 @@ pip install -e .
 
 Le packaging est limite au package `app` (Alembic exclu).
 
-### Mypy
-
-Executez depuis backend:
+### Mypy (depuis backend)
 
 ```
 python -m mypy --config-file ../mypy.ini app tests
 ```
 
-ou
+Ou via le wrapper root:
 
 ```
 pwsh -NoLogo -NoProfile -File ..\PS1\mypy_backend.ps1

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional, cast
 
 import jwt
-from passlib.context import CryptContext  # type: ignore[import-untyped, unused-ignore]
+from passlib.context import CryptContext  # type: ignore[import-untyped]
 from fastapi import Depends, HTTPException, status, Request, Response
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,23 +1,22 @@
 [mypy]
 python_version = 3.12
-
-# On appelle mypy en cwd=backend avec "app tests", donc pas besoin de mypy_path
-
-warn_unused_ignores = True
-warn_redundant_casts = True
-no_implicit_optional = True
 pretty = True
 show_error_codes = True
 explicit_package_bases = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
 
-# Notre code strict
+# On lance mypy en CWD=backend et on cible app/ + tests/
+# donc pas de mypy_path exotique requis.
 
 [mypy-app.*]
 ignore_missing_imports = False
+
 [mypy-tests.*]
 ignore_missing_imports = False
 
-# Libs tiers (pas de stubs)
+# Libs tiers sans stubs
 
 [mypy-fastapi.*]
 ignore_missing_imports = True
@@ -43,3 +42,4 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-uvicorn.*]
 ignore_missing_imports = True
+


### PR DESCRIPTION
## Summary
- remove leftover mypy ignore on passlib import
- add PowerShell helper to run mypy from backend using shared config
- document backend mypy usage in root and backend READMEs

## Testing
- `python -m ruff check backend`
- `python -m mypy --config-file ../mypy.ini app tests`
- `python -m pytest -q backend/tests/test_conflicts_service_ok.py backend/tests/test_conflicts_service_ko.py`


------
https://chatgpt.com/codex/tasks/task_e_68b543c19dc48330ad3364cd37718f34