### PR TITLE
J17 Fix: normalize ISO Z in conflicts service (SQLite)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -283,3 +283,9 @@ curl -Method Post -Uri http://localhost:8000/api/v1/availabilities/1:approve -He
 
 GET /api/v1/conflicts/user/{user_id} -> { user_id, items: [] }
 
+### Note SQLite et timestamps ISO avec `Z`
+
+Sous SQLite, nos colonnes `starts_at/ends_at` sont stockees en `TEXT`. Lorsque les tests inserent des valeurs comme `2025-09-02T09:00:00Z`,
+le dialecte SQLAlchemy peut echouer a parser `Z`. Le service `app.services.conflicts` contourne ce point en lisant ces colonnes en `TEXT`
+et en normalisant `Z` vers `+00:00` avant comparaison. Aucun changement d API.
+

--- a/backend/tests/test_conflicts_normalize_dt.py
+++ b/backend/tests/test_conflicts_normalize_dt.py
@@ -1,0 +1,13 @@
+from app.services.conflicts import _normalize_iso_utc
+
+
+def test_normalize_iso_z_to_offset() -> None:
+    d = _normalize_iso_utc("2025-09-02T09:00:00Z")
+    assert d.tzinfo is not None
+    assert d.isoformat().endswith("+00:00")
+
+
+def test_normalize_iso_space_ok() -> None:
+    d = _normalize_iso_utc("2025-09-02 09:00:00Z")
+    assert d.tzinfo is not None
+


### PR DESCRIPTION
## Summary
- bypass SQLAlchemy datetime parsing for conflicts service by querying TEXT columns and normalizing `Z` to `+00:00`
- document SQLite ISO timestamp quirk
- add regression test for timestamp normalization

## Testing
- `python3 -m ruff check backend`
- `python3 tools/mypy_backend.py`
- `PYTHONPATH=backend python3 -m pytest backend/tests/test_conflicts_normalize_dt.py -q -vv`
- `PYTHONPATH=backend python3 -m pytest -q backend/tests/test_conflicts_service_ok.py backend/tests/test_conflicts_service_ko.py backend/tests/test_conflicts_normalize_dt.py -vv` *(fails: no such table: org_memberships)*


------
https://chatgpt.com/codex/tasks/task_e_68b56f822950833093272615c80c30a3