### PR TITLE
J17 Fix: mypy MappingResult->RowMapping + note migrations tests conflits

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,13 @@ Le packaging est limite au package `app` (Alembic exclu).
 
 Les stubs Alembic sont sous `typing_stubs/alembic`.
 
+### Tests conflits: migrations requises
+Les tests d’integration du service conflits (`test_conflicts_service_ok.py` / `test_conflicts_service_ko.py`) supposent une base SQLite migree.
+Utilisez les fixtures/tests qui appellent Alembic upgrade (ex: `_upgrade(TEST_DB_URL)` dans `tests/utils.py`).
+Lancer uniquement ces 2 fichiers sans la sequence de migration peut produire `OperationalError: no such table: org_memberships`.
+Recommandation:
+PYTHONPATH=backend python -m pytest -q -k "conflicts" -vv
+
 ## Jalon 1 - Backend skeleton + healthz
 
 * GET /healthz -> 200 JSON {"status":"ok"}


### PR DESCRIPTION
## Summary
- use SQLAlchemy `RowMapping` and `.mappings().all()` for conflict queries
- document that conflict tests require DB migrations

## Testing
- `python -m ruff check backend`
- `PYTHONPATH=backend python -m mypy --config-file ../mypy.ini app tests`
- `PYTHONPATH=backend python -m pytest -q -k "conflicts" -vv`

Labels: tests, bug, docs-required

------
https://chatgpt.com/codex/tasks/task_e_68b575c913e88330a026dfb43eeb56f3