### PR TITLE
chore(frontend): fix storybook workflow guard, chromatic non-bloquant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,5 @@ PLAYWRIGHT_BASE_URL=http://localhost:5173
 INVITES_SECRET=dev-secret
 INVITES_TTL_SECONDS=604800
 
-# Chromatic project token (facultatif en local; requis pour publication CI)
+# Chromatic project token (optionnel en local; requis pour publication CI)
 CHROMATIC_PROJECT_TOKEN=

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -40,7 +40,6 @@ jobs:
     name: publish-chromatic
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ secrets.CHROMATIC_PROJECT_TOKEN != '' && secrets.CHROMATIC_PROJECT_TOKEN != null }}
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
     defaults:
@@ -57,6 +56,11 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install deps
         run: npm ci
+      - name: Skip (token absent)
+        if: ${{ env.CHROMATIC_PROJECT_TOKEN == '' || env.CHROMATIC_PROJECT_TOKEN == null }}
+        run: echo "CHROMATIC_PROJECT_TOKEN absent. Publication Chromatic ignoree."
       - name: Publish to Chromatic
+        if: ${{ env.CHROMATIC_PROJECT_TOKEN != '' && env.CHROMATIC_PROJECT_TOKEN != null }}
         run: |
           npx chromatic --project-token "$CHROMATIC_PROJECT_TOKEN" --ci --only-changed --exit-zero-on-changes --auto-accept-changes
+        continue-on-error: true

--- a/PS1/storybook_chromatic.ps1
+++ b/PS1/storybook_chromatic.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
 if ([string]::IsNullOrWhiteSpace($Env:CHROMATIC_PROJECT_TOKEN)) {
-    Write-Warning "CHROMATIC_PROJECT_TOKEN absent. Publication Chromatic sautee."
+    Write-Warning "CHROMATIC_PROJECT_TOKEN absent. Publication Chromatic ignoree."
     exit 0
 }
 
@@ -15,12 +15,12 @@ $frontend = Join-Path $root "frontend"
 Push-Location $frontend
 try {
     if ($DryRun) {
-        Write-Host "[i] DryRun Chromatic. Commande affichee:"
+        Write-Host "[i] DryRun Chromatic. Commande:"
         Write-Host "npx chromatic --project-token *** --ci --only-changed --exit-zero-on-changes --auto-accept-changes"
         exit 0
     }
-    npx chromatic --project-token $Env:CHROMATIC_PROJECT_TOKEN --ci --build-script-name build:storybook --only-changed --exit-zero-on-changes --auto-accept-changes
-    Write-Host "[OK] Publication Chromatic reussie."
+    npx chromatic --project-token $Env:CHROMATIC_PROJECT_TOKEN --ci --only-changed --exit-zero-on-changes --auto-accept-changes
+    Write-Host "[OK] Publication Chromatic OK."
     exit 0
 }
 catch {

--- a/README.md
+++ b/README.md
@@ -63,15 +63,14 @@ python tools\mypy_backend.py
 
 ## Storybook et Chromatic
 
-* Build local (Windows):
-  pwsh -NoLogo -NoProfile -File PS1/storybook_build.ps1
-* Build local (Linux/Mac):
-  bash tools/storybook_build.sh
-* Publication Chromatic (CI ou local):
-  Definir CHROMATIC_PROJECT_TOKEN, puis:
-  pwsh -NoLogo -NoProfile -File PS1/storybook_chromatic.ps1
-* CI publie automatiquement a Chromatic si le secret `CHROMATIC_PROJECT_TOKEN` est present.
-* Note: `storybook build` n accepte plus `--ci`. L option `--ci` reste valide pour `chromatic`.
+Windows:
+pwsh -NoLogo -NoProfile -File PS1/storybook_build.ps1
+Linux/Mac:
+bash tools/storybook_build.sh
+Publication Chromatic (si token defini):
+$Env:CHROMATIC_PROJECT_TOKEN="<votre_token>"
+pwsh -NoLogo -NoProfile -File PS1/storybook_chromatic.ps1
+CI: la job "publish-chromatic" s execute uniquement si `CHROMATIC_PROJECT_TOKEN` est present; sinon elle log "ignoree". Non-bloquant.
 
 ### Politique README
 
@@ -113,7 +112,7 @@ Tests:
 ## Envs requis
 
 Voir .env.example. Pas de secrets dans le repo. Ajout de `INVITES_SECRET` et `INVITES_TTL_SECONDS` pour les tokens d'invitation.
-Variables: `VITE_API_BASE`, `PLAYWRIGHT_BASE_URL`.
+Variables: `VITE_API_BASE`, `PLAYWRIGHT_BASE_URL`, `CHROMATIC_PROJECT_TOKEN` (optionnel).
 
 ## Ports
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -35,7 +35,7 @@ Note: executer ces commandes dans `frontend/`.
 
 * npm run storybook : lance Storybook dev
 * npm run build:storybook : compile le site statique
-* npm run chromatic : publie sur Chromatic (requiert CHROMATIC_PROJECT_TOKEN)
+* npm run chromatic : publie sur Chromatic (requis: CHROMATIC_PROJECT_TOKEN)
 
 ### Secrets
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "storybook": "storybook dev -p 6006",
     "prepare": "husky install",
     "build:storybook": "node -e \"process.env.NODE_OPTIONS='--max-old-space-size=4096'\" && storybook build",
-    "chromatic": "chromatic --build-script-name build:storybook --only-changed --exit-zero-on-changes --auto-accept-changes",
+    "chromatic": "chromatic --only-changed --exit-zero-on-changes --auto-accept-changes",
     "test:storybook": "storybook test --ci",
     "size": "size-limit",
     "lint:a11y": "echo \"a11y via test-runner\""


### PR DESCRIPTION
## Summary
- guard Chromatic publication via step-level env token and keep it non-blocking
- drop phantom workflow and clean build scripts for Storybook
- document Storybook/Chromatic usage and env token

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/storybook_build.ps1` *(fails: command not found)*
- `bash tools/storybook_build.sh`
- `npx chromatic --project-token "$CHROMATIC_PROJECT_TOKEN" --only-changed --exit-zero-on-changes --auto-accept-changes --storybook-build-dir storybook-static || echo "Attendu: echec auth"`


------
https://chatgpt.com/codex/tasks/task_e_68b592267b208330aa209300ae89f687