### PR TITLE
fix(storybook): ensure router context

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,20 +1,20 @@
 import "../src/index.css";
 import type { Preview } from "@storybook/react";
-import React from "react";
+import { MemoryRouter } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "../src/lib/queryClient";
-import { MemoryRouter } from "react-router-dom";
 
-const withProviders = (Story: React.ComponentType) => (
-  <MemoryRouter basename="/" initialEntries={["/"]}>
-    <QueryClientProvider client={queryClient}>
-      <Story />
-    </QueryClientProvider>
-  </MemoryRouter>
-);
+export const decorators: Preview["decorators"] = [
+  (Story) => (
+    <MemoryRouter initialEntries={["/"]} basename="/">
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    </MemoryRouter>
+  ),
+];
 
 const preview: Preview = {
-  decorators: [withProviders],
   parameters: {
     actions: { argTypesRegex: "^on[A-Z].*" },
     controls: {

--- a/frontend/src/stories/Header.stories.tsx
+++ b/frontend/src/stories/Header.stories.tsx
@@ -1,23 +1,21 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { AppLayout } from "../ui/AppLayout";
 
-const meta: Meta<typeof AppLayout> = {
+const meta = {
   title: "Layout/AppLayout",
   component: AppLayout,
-  // Garde-fou si une story consomme le Router (basename/useLocation) avant le decorateur global
   decorators: [
     (Story) => (
-      <MemoryRouter basename="/" initialEntries={["/"]}>
+      <MemoryRouter initialEntries={["/"]} basename="/">
         <Story />
       </MemoryRouter>
     ),
   ],
-};
+} satisfies Meta<typeof AppLayout>;
+
 export default meta;
 
-type Story = StoryObj<typeof AppLayout>;
-export const Default: Story = {
-  args: {},
-};
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary
- wrap Storybook stories in a global MemoryRouter
- protect AppLayout story with a local MemoryRouter decorator

## Testing
- `npm run build-storybook`
- `npx test-storybook --url http://127.0.0.1:6006 --maxWorkers=2` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1134/chrome-linux/chrome)*
- `npx playwright install chromium` *(fails: Download failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a53ef77c8330b0ea9a1c1d191e03