### PR TITLE
Fix CI notifications (ruff+mypy)

### DIFF
--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import enum
 import uuid
-from sqlalchemy import Column, String, DateTime, Enum, JSON, func
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, JSON, func
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db import Base
 
@@ -29,15 +32,21 @@ class NotificationStatus(str, enum.Enum):
 class Notification(Base):
     __tablename__ = "notifications"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id = Column(UUID(as_uuid=True), nullable=False, index=True)
-    channel = Column(Enum(Channel), nullable=False)
-    ntype = Column(Enum(NotificationType), nullable=False)
-    payload = Column(JSON, nullable=False)
-    status = Column(
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    channel: Mapped[Channel] = mapped_column(Enum(Channel), nullable=False)
+    ntype: Mapped[NotificationType] = mapped_column(Enum(NotificationType), nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
+    status: Mapped[NotificationStatus] = mapped_column(
         Enum(NotificationStatus), nullable=False, default=NotificationStatus.queued
     )
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    read_at = Column(DateTime(timezone=True), nullable=True)
+    read_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/tests/test_notifications_email.py
+++ b/tests/test_notifications_email.py
@@ -1,0 +1,50 @@
+
+# Aligner les imports sur le package existant: app.*
+
+from app.services.notifications import email as email_svc
+
+import types
+
+
+class DummySMTP:
+    def __init__(self, host, port, timeout=10):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def starttls(self):
+        pass
+
+    def login(self, u, p):
+        pass
+
+    def send_message(self, msg):
+        self.sent = True
+
+
+def test_send_email_monkeypatch(monkeypatch):
+    monkeypatch.setattr(
+        email_svc, "smtplib", types.SimpleNamespace(SMTP=DummySMTP)
+    )
+    res = email_svc.send_email(
+        "localhost",
+        1025,
+        None,
+        None,
+        "no-reply@test",
+        "dev@test",
+        "Subj",
+        "invite",
+        {
+            "user_name": "Sam",
+            "mission": "Covertramp",
+            "accept_url": "a",
+            "decline_url": "d",
+        },
+    )
+    assert res["ok"] is True
+

--- a/tests/test_notifications_rate_limit.py
+++ b/tests/test_notifications_rate_limit.py
@@ -1,0 +1,10 @@
+from app.services.notifications.rate_limit import RateLimiter
+
+
+def test_rate_limit_mem_window():
+    rl = RateLimiter()
+    hits = 0
+    for _ in range(6):
+        hits = rl.hit("k", 1)  # 1s window
+    assert hits == 6
+

--- a/tests/test_notifications_tokens.py
+++ b/tests/test_notifications_tokens.py
@@ -1,0 +1,11 @@
+from app.services.notifications.tokens import sign_token, verify_token, build_links
+
+
+def test_sign_and_verify():
+    tok = sign_token("secret", "assign-1", "user-1", ttl_sec=60)
+    ok, info = verify_token("secret", tok)
+    assert ok and info is not None
+    assert info["assignment_id"] == "assign-1" and info["user_id"] == "user-1"
+    links = build_links("http://x", tok)
+    assert "accept" in links["accept_url"] and "decline" in links["decline_url"]
+


### PR DESCRIPTION
## Summary
- tighten notification model with SQLAlchemy typing and drop unused import
- add Redis protocol and in-memory fallback guards to rate limiter
- harden notification router Telegram handling and token verification
- align notification tests with `app.*` imports

## Testing
- `python -m ruff check backend`
- `MYPYPATH=typing_stubs python -m mypy --config-file ../mypy.ini app`
- `PYTHONPATH=backend python -m pytest -q tests/test_notifications_tokens.py tests/test_notifications_rate_limit.py tests/test_notifications_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6c48ae9cc83308215f26487946842