### PR TITLE
Fix CI mypy: align imports tests vers app.*

### DIFF
--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,2 +1,4 @@
-from typing import List
-__all__: List[str] = []
+"""Service package"""
+
+# assure package
+__all__ = ["notifications"]

--- a/backend/app/services/notifications/__init__.py
+++ b/backend/app/services/notifications/__init__.py
@@ -1,1 +1,4 @@
-# Notification service package
+"""Notifications service package"""
+
+# assure package
+__all__ = ["email", "telegram", "compose", "rate_limit", "tokens"]

--- a/backend/tests/test_notifications_email.py
+++ b/backend/tests/test_notifications_email.py
@@ -1,6 +1,6 @@
 import types
 
-from backend.app.services.notifications import email as email_svc
+from app.services.notifications import email as email_svc
 
 
 class DummySMTP:

--- a/backend/tests/test_notifications_rate_limit.py
+++ b/backend/tests/test_notifications_rate_limit.py
@@ -1,4 +1,4 @@
-from backend.app.services.notifications.rate_limit import RateLimiter
+from app.services.notifications.rate_limit import RateLimiter
 
 
 def test_rate_limit_mem_window():

--- a/backend/tests/test_notifications_tokens.py
+++ b/backend/tests/test_notifications_tokens.py
@@ -1,4 +1,8 @@
-from backend.app.services.notifications.tokens import sign_token, verify_token, build_links
+from app.services.notifications.tokens import (
+    build_links,
+    sign_token,
+    verify_token,
+)
 
 
 def test_sign_and_verify():


### PR DESCRIPTION
## Summary
- align notification tests with app.* package for mypy runner
- ensure notifications packages are explicit modules

## Testing
- `backend.venv/Scripts/python -m ruff check backend`
- `backend.venv/Scripts/python tools/mypy_backend.py`
- `backend.venv/Scripts/python -m pytest backend/tests/test_notifications_tokens.py backend/tests/test_notifications_rate_limit.py backend/tests/test_notifications_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6c7bac52483309e8ec94331a20d24