### PR TITLE
Fix CI J19 (lint, mypy, e2e)

### DIFF
--- a/PS1/repro_ci_j19.ps1
+++ b/PS1/repro_ci_j19.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+Write-Host "== Ruff =="
+backend.venv\Scripts\python -m ruff check backend
+
+Write-Host "== mypy backend =="
+backend.venv\Scripts\python tools/mypy_backend.py
+
+Write-Host "== E2E FE smoke =="
+cd frontend
+npm run e2e:smoke
+cd ..

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Tests/Lint
 
 * backend.venv\Scripts\python -m pytest -q --disable-warnings --maxfail=1
 * npm run e2e:smoke
+
+## Notes CI (J19)
+
+* ReportLab n expose pas de stubs types. Les imports sont ignores finement via `# type: ignore[import-not-found, import-untyped, unused-ignore]` sur `reportlab.lib.pagesizes` et `reportlab.pdfgen`. Aucun impact runtime.
 ## CI
 
 - backend: ruff, mypy, pytest

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 
 
 class JsonFormatter(logging.Formatter):
-    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+    def format(self, record: logging.LogRecord) -> str:
         payload: Dict[str, Any] = {
             "level": record.levelname,
             "logger": record.name,

--- a/backend/app/services/exports.py
+++ b/backend/app/services/exports.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import csv
-from datetime import datetime
 from io import BytesIO, StringIO
 from typing import List
 
-from reportlab.lib.pagesizes import A4
-from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import A4  # type: ignore[import-not-found, import-untyped, unused-ignore]
+from reportlab.pdfgen import canvas  # type: ignore[import-not-found, import-untyped, unused-ignore]
 
 
 def to_csv_monthly_users(items: List[dict]) -> bytes:

--- a/backend/cli/cc.py
+++ b/backend/cli/cc.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import requests
 import typer
 

--- a/frontend/src/pages/Accounting/MonthlyUsers.tsx
+++ b/frontend/src/pages/Accounting/MonthlyUsers.tsx
@@ -4,7 +4,6 @@ import {
   exportCSV,
   type MonthlyUserItem,
 } from "../../api/reports";
-import CSVButton from "../../components/CSVButton";
 
 export default function MonthlyUsers() {
   const [orgId, setOrgId] = React.useState<string>("");
@@ -92,7 +91,14 @@ export default function MonthlyUsers() {
           >
             Charger
           </button>
-          <CSVButton onClick={onExport} disabled={!items.length} />
+          <button
+            onClick={onExport}
+            aria-label="Export CSV"
+            className="px-3 py-2 rounded-2xl shadow border text-sm"
+            disabled={!items.length}
+          >
+            Export CSV
+          </button>
         </div>
       </div>
       {error && <div className="text-red-600 text-sm">{error}</div>}

--- a/frontend/tests/e2e/accounting-smoke.spec.ts
+++ b/frontend/tests/e2e/accounting-smoke.spec.ts
@@ -6,5 +6,8 @@ test("@smoke Accounting monthly users page smoke", async ({ page }) => {
     page.getByText("Comptabilite - Totaux mensuels par user")
   ).toBeVisible();
   await expect(page.getByRole("button", { name: "Charger" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Export CSV" })).toBeVisible();
+
+  // Le bouton est desactive tant qu'il n'y a pas de donnees mais doit etre present.
+  const exportBtn = page.getByRole("button", { name: /export csv/i });
+  await expect(exportBtn).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- silence missing reportlab type hints and drop unused imports
- tidy JSON logging helper
- ensure Export CSV button is accessible and relax e2e locator
- document reportlab mypy ignore and add CI repro script

## Testing
- `python -m ruff check backend`
- `python tools/mypy_backend.py`
- `npm run e2e:smoke` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d88a306083309adbc74cfb5a8c5c