### PR TITLE
Fix py310 UTC (reports/exports)

### DIFF
--- a/PS1/repro_py310_utc.ps1
+++ b/PS1/repro_py310_utc.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version Latest
+Write-Host "== Pytest backend (UTC py310 fix) =="
+backend.venv\Scripts\python -m pytest -q --disable-warnings --maxfail=1

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Tests/Lint
 ## Notes CI (J19)
 
 * ReportLab n expose pas de stubs types. Les imports sont ignores finement via `# type: ignore[import-not-found, import-untyped, unused-ignore]` sur `reportlab.lib.pagesizes` et `reportlab.pdfgen`. Aucun impact runtime.
+* Compatibilite Python: la CI Windows tourne en Python 3.10. Utiliser `datetime.timezone.utc` (et non `datetime.UTC` qui est 3.11+).
 ## CI
 
 - backend: ruff, mypy, pytest

--- a/backend/README.md
+++ b/backend/README.md
@@ -343,6 +343,7 @@ GET /api/v1/exports/ics?project_id&date_from&date_to
 ### Conventions de calcul
 
 * UTC base, mois AAAA-MM par start_utc
+* UTC: conversions via `timezone.utc` pour compat 3.10+.
 * heures_prevues = duree mission
 * heures_confirmees = (status ACCEPTED) ? confirmed_hours || duree : 0
 * rate_profile: hourly => h_confirmees*rate ; flat => forfait si ACCEPTED

--- a/backend/app/api/v1/exports.py
+++ b/backend/app/api/v1/exports.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
@@ -28,8 +28,8 @@ def export_csv(
             detail="Type d export non supporte.",
         )
     try:
-        df = datetime.fromisoformat(date_from).replace(tzinfo=UTC)
-        dt = datetime.fromisoformat(date_to).replace(tzinfo=UTC)
+        df = datetime.fromisoformat(date_from).replace(tzinfo=timezone.utc)
+        dt = datetime.fromisoformat(date_to).replace(tzinfo=timezone.utc)
     except Exception:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Dates invalides.")
     items = compute_monthly_totals(
@@ -59,8 +59,8 @@ def export_pdf(
             detail="Type d export non supporte.",
         )
     try:
-        df = datetime.fromisoformat(date_from).replace(tzinfo=UTC)
-        dt = datetime.fromisoformat(date_to).replace(tzinfo=UTC)
+        df = datetime.fromisoformat(date_from).replace(tzinfo=timezone.utc)
+        dt = datetime.fromisoformat(date_to).replace(tzinfo=timezone.utc)
     except Exception:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Dates invalides.")
     items = compute_monthly_totals(

--- a/backend/app/api/v1/reports.py
+++ b/backend/app/api/v1/reports.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -22,8 +22,8 @@ def monthly_users(
     db: Session = Depends(get_db),
 ):
     try:
-        df = datetime.fromisoformat(date_from).replace(tzinfo=UTC)
-        dt = datetime.fromisoformat(date_to).replace(tzinfo=UTC)
+        df = datetime.fromisoformat(date_from).replace(tzinfo=timezone.utc)
+        dt = datetime.fromisoformat(date_to).replace(tzinfo=timezone.utc)
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
@@ -20,7 +20,7 @@ class _Row:
 
 
 def _month_key(dt: datetime) -> str:
-    dt = dt.astimezone(UTC)
+    dt = dt.astimezone(timezone.utc)
     return f"{dt.year:04d}-{dt.month:02d}"
 
 


### PR DESCRIPTION
## Summary
- replace deprecated datetime.UTC imports with timezone.utc to support Python 3.10
- document UTC timezone compatibility
- add regression script for py310 UTC tests

## Testing
- `backend.venv/Scripts/python -m pytest -q --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68b6ddc5d4088330ab1e10f3d735d412