### PR TITLE
Fix mypy reportlab import-untyped + unused-ignore (lazy import + config)

### DIFF
--- a/PS1/tests/mypy_exports.ps1
+++ b/PS1/tests/mypy_exports.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+Push-Location (Join-Path $PSScriptRoot "..\..")
+try {
+  # Repro rapide mypy (meme logique que CI)
+  $env:PYTHONPATH = "backend"
+  python tools/mypy_backend.py
+  Write-Host "mypy OK"
+  exit 0
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+} finally {
+  Pop-Location
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,13 @@ Le packaging est limite au package `app` (Alembic exclu).
 
 Les stubs Alembic sont sous `typing_stubs/alembic`.
 
+## Exports (CSV/PDF/ICS)
+- CSV et ICS fonctionnent sans deps additionnelles.
+- PDF: dependance **optionnelle** via `reportlab`. En local:
+  - `pip install reportlab`
+  - La CI mypy ignore `reportlab.*` (voir `backend/mypy.ini`) afin d eviter les erreurs de stubs.
+  - Le code importe `reportlab` en **lazy** au moment de generer le PDF.
+
 ### Tests conflits: migrations requises
 Les tests d’integration du service conflits (`test_conflicts_service_ok.py` / `test_conflicts_service_ko.py`) supposent une base SQLite migree.
 Utilisez les fixtures/tests qui appellent Alembic upgrade (ex: `_upgrade(TEST_DB_URL)` dans `tests/utils.py`).

--- a/backend/app/services/exports.py
+++ b/backend/app/services/exports.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import csv
 from io import BytesIO, StringIO
-from typing import List
+from typing import Any, List, Tuple
 
 
 
@@ -22,16 +22,23 @@ def to_csv_monthly_users(items: List[dict]) -> bytes:
     return buf.getvalue().encode("utf-8")
 
 
+def _import_reportlab() -> Tuple[Any, Any]:
+    """Import runtime de reportlab (A4 et canvas)."""
+    try:
+        from reportlab.lib.pagesizes import A4  # runtime only
+        from reportlab.pdfgen import canvas  # runtime only
+        return A4, canvas
+    except Exception as exc:  # pragma: no cover - dependance manquante
+        raise RuntimeError(
+            "Export PDF indisponible: module 'reportlab' non installe."
+        ) from exc
+
+
 def to_pdf_monthly_users(
     items: List[dict],
     title: str = "Totaux mensuels par utilisateur",
 ) -> bytes:
-    # Import paresseux pour eviter l'erreur si reportlab n'est pas installe.
-    try:
-        from reportlab.lib.pagesizes import A4  # type: ignore[import-not-found]
-        from reportlab.pdfgen import canvas  # type: ignore[import-not-found]
-    except Exception as e:  # pragma: no cover - dependance manquante
-        raise RuntimeError("PDF_EXPORT_UNAVAILABLE") from e
+    A4, canvas = _import_reportlab()
 
     buf = BytesIO()
     c = canvas.Canvas(buf, pagesize=A4)

--- a/mypy.ini
+++ b/mypy.ini
@@ -43,3 +43,7 @@ ignore_missing_imports = True
 [mypy-uvicorn.*]
 ignore_missing_imports = True
 
+[mypy-reportlab.*]
+ignore_missing_imports = True
+follow_imports = skip
+


### PR DESCRIPTION
## Summary
- import reportlab lazily for PDF exports without module-level type ignores
- silence missing reportlab stubs in mypy config
- document optional PDF dependency and add repro script for mypy

## Testing
- `python tools/mypy_backend.py`
- `PYTHONPATH=backend python -m pytest backend/tests/test_exports_endpoints.py -q -vv`
- ⚠️ `pwsh PS1/tests/mypy_exports.ps1` *(missing pwsh command)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e61c17008330b673d72117a471c7