### PR TITLE
Fix CI J19.1: ruff Optional + mypy path backend

### DIFF
--- a/PS1/tests/mypy_fix.ps1
+++ b/PS1/tests/mypy_fix.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+Push-Location (Join-Path $PSScriptRoot "....")
+try {
+    $env:PYTHONPATH = "backend"
+    python tools/mypy_backend.py
+    Write-Host "mypy OK"
+    exit 0
+} catch {
+    Write-Error $_.Exception.Message
+    exit 1
+} finally {
+    Pop-Location
+}
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,10 @@ Le packaging est limite au package `app` (Alembic exclu).
 
 Les stubs Alembic sont sous `typing_stubs/alembic`.
 
+## Notes CI / Typage
+
+* mypy utilise `backend/mypy.ini` et force `mypy_path=backend`. Le runner appelle `tools/mypy_backend.py` qui insere `backend/` dans `sys.path` et `MYPYPATH`. Cela garantit que les imports `from backend.app...` resolvent correctement sous Windows/Linux. (cf. Roadmap: CI verte a chaque jalon).
+
 ## Exports (CSV/PDF/ICS)
 - CSV et ICS fonctionnent sans deps additionnelles.
 - PDF: dependance **optionnelle** via `reportlab`. En local:

--- a/backend/app/services/ics.py
+++ b/backend/app/services/ics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List
 
 from sqlalchemy.orm import Session
 

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+python_version = 3.12
+warn_unused_ignores = True
+namespace_packages = True
+mypy_path = backend
+
+[mypy-reportlab.*]
+ignore_missing_imports = True
+follow_imports = skip
+

--- a/tools/mypy_backend.py
+++ b/tools/mypy_backend.py
@@ -1,17 +1,35 @@
+#!/usr/bin/env python
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
+from pathlib import Path
+from mypy import api as mypy_api
 
+ROOT = Path(__file__).resolve().parent.parent
+BACKEND = ROOT / "backend"
+CONFIG = BACKEND / "mypy.ini"
 
-def main() -> int:
-    os.chdir("backend")
-    os.environ["MYPYPATH"] = "typing_stubs"
-    cmd = [sys.executable, "-m", "mypy", "--config-file", "../mypy.ini", "app", "tests"]
-    return subprocess.call(cmd)
+# Forcer la resolution pour le package "backend"
+os.environ.setdefault("MYPYPATH", str(BACKEND))
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
 
+targets = [str(BACKEND / "app")]
+bt = BACKEND / "tests"
+rt = ROOT / "tests"
+if bt.exists():
+    targets.append(str(bt))
+if rt.exists():
+    targets.append(str(rt))
 
-if __name__ == "__main__":
-    raise SystemExit(main())
+args = ["--config-file", str(CONFIG)] + targets
+stdout, stderr, status = mypy_api.run(args)
+
+# Rejoue la sortie comme la CI attend
+if stdout:
+    print(stdout, end="")
+if stderr:
+    print(stderr, end="", file=sys.stderr)
+raise SystemExit(status)
 


### PR DESCRIPTION
## Summary
- remove unused Optional in ics service to satisfy ruff
- configure mypy for namespace package backend and expose runner script
- document backend mypy path and add PS script

## Testing
- `python -m ruff check backend tools/mypy_backend.py`
- `MYPYPATH=. python -m mypy --config-file backend/mypy.ini backend/app`
- `PYTHONPATH=backend python -m pytest -q --disable-warnings --maxfail=1 -k "ics or cache"` *(fails: Duplicated timeseries in CollectorRegistry: {'app_requests_total', 'app_requests_created', 'app_requests'})*

------
https://chatgpt.com/codex/tasks/task_e_68b6fa3df0d8833087fa002ee2a45d24