### PR TITLE
Fix tests monkeypatch + mypy (pytest/typer)

### DIFF
--- a/PS1/tests/repro_tests_mypy.ps1
+++ b/PS1/tests/repro_tests_mypy.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+Write-Host "== Ruff =="
+backend.venv\Scripts\python -m ruff check backend
+Write-Host "== mypy =="
+python tools/mypy_backend.py
+Write-Host "== pytest ciblé =="
+backend.venv\Scripts\python -m pytest -q --disable-warnings --maxfail=1 -k "reports_monthly_users or exports_ics"

--- a/backend/README.md
+++ b/backend/README.md
@@ -26,6 +26,7 @@ Les stubs Alembic sont sous `typing_stubs/alembic`.
 
 * Mypy est lance via `tools/mypy_backend.py` avec `--explicit-package-bases` et cible le package `backend`. La racine repo est sur `sys.path` (pas `backend/`), evitant le doublon `app.*` vs `backend.app.*`.
 * Les libs externes (FastAPI, SQLAlchemy, Pydantic, etc.) sont ignorees pour le typage (sections `[mypy-*.]`), afin de ne pas exiger leurs stubs.
+* Mypy ignore aussi `pytest.*` et `typer.*` (tests/CLI) pour eviter l'exigence de stubs tiers.
 
 ## Exports (CSV/PDF/ICS)
 - CSV et ICS fonctionnent sans deps additionnelles.

--- a/backend/app/api/v1/reports.py
+++ b/backend/app/api/v1/reports.py
@@ -10,6 +10,10 @@ from ...schemas.reports import MonthlyUserItem, MonthlyUsersResponse
 from ...services.reports import compute_monthly_totals_cached
 from ...db import get_db
 
+# Alias pour compatibilité des tests: le nom historique
+# ``compute_monthly_totals`` est toujours monkeypatché.
+compute_monthly_totals = compute_monthly_totals_cached
+
 router = APIRouter(prefix="/api/v1/reports", tags=["reports"])
 
 
@@ -34,7 +38,8 @@ def monthly_users(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Plage de dates invalide: date_from > date_to.",
         )
-    items = compute_monthly_totals_cached(
+    # Utilise l'alias compatible pour permettre le monkeypatch dans les tests.
+    items = compute_monthly_totals(
         db, org_id=org_id, project_id=project_id, date_from=df, date_to=dt
     )
     return MonthlyUsersResponse(

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -54,3 +54,11 @@ follow_imports = skip
 ignore_missing_imports = True
 follow_imports = skip
 
+[mypy-pytest.*]
+ignore_missing_imports = True
+follow_imports = skip
+
+[mypy-typer.*]
+ignore_missing_imports = True
+follow_imports = skip
+


### PR DESCRIPTION
## Summary
- expose `compute_monthly_totals` alias for cached reports to restore test monkeypatch compatibility
- ignore missing stubs for `pytest` and `typer` in mypy configuration
- document new mypy ignores and add reproduction script for lint/type/test run

## Testing
- `backend.venv/Scripts/python -m ruff check backend`
- `python tools/mypy_backend.py`
- `backend.venv/Scripts/python -m pytest -q --disable-warnings --maxfail=1 -k "reports_monthly_users or exports_ics"`


------
https://chatgpt.com/codex/tasks/task_e_68b708c87394833086c78159c3083fe1