### PR TITLE
Fix docker-smoke: bind 0.0.0.0 + /healthz + CMD uvicorn

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app/backend
+
+WORKDIR /app
+
+# Copie deps (adapter si vous avez un lock)
+COPY backend/pyproject.toml backend/ ./
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -e backend
+
+# Copie du code
+COPY backend/ backend/
+
+EXPOSE 8000
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ pwsh -NoLogo -NoProfile -File PS1/dev_up.ps1
 pwsh -NoLogo -NoProfile -File PS1/smoke.ps1
 ```
 
+## Endpoints de sante
+
+* GET /health et GET /healthz -> 200 {"status":"ok"}
+* CI docker-smoke ping /healthz sur http://localhost:8000
+
+## Docker (backend)
+
+* Port: 8000 expose
+* CMD: `uvicorn backend.app.main:app --host 0.0.0.0 --port 8000`
+* `PYTHONPATH=/app/backend` pour resoudre `backend.app.*`
+
 Ports: BE 8000 ; FE 5173 ; DB 5432 ; Redis 6379 ; Adminer 8080 ; Prom 9090 ; Grafana 3000 ; Mailpit 8025.
 Voir `deploy/README.md` pour details (compose, observabilite). Roadmap: relire `docs/roadmap.md`.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,6 +9,11 @@ pip install -e .
 
 Le packaging est limite au package `app` (Alembic exclu).
 
+## Sante
+
+* /health et /healthz (alias pour la CI)
+* Uvicorn ecoute 0.0.0.0:8000 (Docker: EXPOSE 8000)
+
 ### Typage (mypy)
 
 * Local:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -100,7 +100,8 @@ def create_app() -> FastAPI:
     metrics_enabled = os.getenv("METRICS_ENABLED", "true").lower() == "true"
     setup_metrics(app, enabled=metrics_enabled)
 
-    @app.get("/healthz")
+    @app.get("/healthz", tags=["meta"])
+    @app.get("/health", tags=["meta"])
     def healthz() -> Dict[str, str]:
         return {"status": "ok"}
 
@@ -137,3 +138,13 @@ def create_app() -> FastAPI:
 
 
 app = create_app()
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    import uvicorn
+
+    uvicorn.run(
+        "backend.app.main:app",
+        host="0.0.0.0",
+        port=int(os.environ.get("PORT", "8000")),
+        reload=False,
+    )

--- a/backend/tests/test_healthz.py
+++ b/backend/tests/test_healthz.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fastapi.testclient import TestClient
 
 from backend.app.main import app
@@ -6,6 +8,12 @@ client = TestClient(app)
 
 
 def test_healthz_ok() -> None:
-    response = client.get("/healthz")
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+def test_health_ok() -> None:
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- expose `/health` alongside `/healthz`
- run `uvicorn` on 0.0.0.0:8000 and add Dockerfile for CI smoke
- document health endpoints and Docker usage

## Testing
- `python -m pytest -q -k "healthz" -vv`
- `curl -sf http://localhost:8000/healthz`
- `docker build -f Dockerfile.backend -t cc-backend .` *(fail: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1` *(fail: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70be35e988330a524ad61e7526cdf