### PR TITLE
Fix mypy(uvicorn) + Dockerfile root pour docker-smoke

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+# Installer deps via pyproject du backend
+COPY backend/pyproject.toml backend/ ./
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -e backend
+
+# Copier le code
+COPY backend/ backend/
+
+EXPOSE 8000
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/PS1/docker_smoke.ps1
+++ b/PS1/docker_smoke.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version Latest
+
+docker build -t cc-backend .
+docker run -d --rm -p 8000:8000 --name cc-backend cc-backend | Out-Null
+try {
+    for ($i=0; $i -lt 30; $i++) {
+        try {
+            Invoke-WebRequest -Uri "http://localhost:8000/healthz" -UseBasicParsing -TimeoutSec 2 | Out-Null
+            Write-Host "OK /healthz"
+            exit 0
+        } catch { Start-Sleep -Seconds 2 }
+    }
+    Write-Error "backend not ready"
+    exit 3
+} finally {
+    docker rm -f cc-backend | Out-Null
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ pwsh -NoLogo -NoProfile -File PS1/smoke.ps1
 * CMD: `uvicorn backend.app.main:app --host 0.0.0.0 --port 8000`
 * `PYTHONPATH=/app/backend` pour resoudre `backend.app.*`
 
+## Docker (backend rapide)
+
+```
+docker build -t cc-backend .
+docker run --rm -p 8000:8000 cc-backend
+curl -s http://localhost:8000/healthz
+```
+
 Ports: BE 8000 ; FE 5173 ; DB 5432 ; Redis 6379 ; Adminer 8080 ; Prom 9090 ; Grafana 3000 ; Mailpit 8025.
 Voir `deploy/README.md` pour details (compose, observabilite). Roadmap: relire `docs/roadmap.md`.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -14,6 +14,22 @@ Le packaging est limite au package `app` (Alembic exclu).
 * /health et /healthz (alias pour la CI)
 * Uvicorn ecoute 0.0.0.0:8000 (Docker: EXPOSE 8000)
 
+## Lancement via Docker
+
+* Image par defaut utilise le `Dockerfile` racine:
+
+  * CMD: `uvicorn backend.app.main:app --host 0.0.0.0 --port 8000`
+  * Ports: 8000 expose
+* Sante: `/health` et `/healthz` -> 200
+
+Tests (PS + curl):
+
+* Typage: `python tools/mypy_backend.py`
+* Docker smoke:
+
+  * `pwsh -NoLogo -NoProfile -File PS1/docker_smoke.ps1`
+  * ou: `docker build -t cc-backend . && docker run --rm -p 8000:8000 cc-backend` puis `curl -sf http://localhost:8000/healthz`
+
 ### Typage (mypy)
 
 * Local:

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -62,3 +62,7 @@ follow_imports = skip
 ignore_missing_imports = True
 follow_imports = skip
 
+[mypy-uvicorn.*]
+ignore_missing_imports = True
+follow_imports = skip
+


### PR DESCRIPTION
## Summary
- ignore missing uvicorn stubs in backend mypy config
- add root Dockerfile to run uvicorn backend for docker-smoke
- document quick Docker usage and add helper PS script

## Testing
- `python tools/mypy_backend.py`
- `bash tools/docs_guard.sh`
- `docker build -t cc-backend .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b70f1f5a2c83309ba5e3ab6797f0c5