### PR TITLE
Fix Docker build: remove editable install; SAFE_MODE deps minimales

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Installer deps via pyproject du backend
-COPY backend/pyproject.toml backend/ ./
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -e backend
+# Deps minimales pour SAFE_MODE (/healthz)
 
-# Copier le code
+# Pins stables pour reproductibilite CI
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir fastapi==0.115.0 uvicorn==0.30.6
+
+# Code backend (routes lourdes protegees par SAFE_MODE)
+
 COPY backend/ backend/
 
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -34,12 +34,15 @@ pwsh -NoLogo -NoProfile -File PS1/smoke.ps1
 * CMD: `uvicorn backend.app.main:app --host 0.0.0.0 --port 8000`
 * `PYTHONPATH=/app/backend` pour resoudre `backend.app.*`
 
-## Docker (backend rapide)
+## Docker (SAFE_MODE)
+
+* Image de smoke: deps minimales (FastAPI+Uvicorn), `SAFE_MODE=1` par defaut -> seules `/health` et `/healthz`.
+* Lancer:
 
 ```
 docker build -t cc-backend .
-docker run --rm -p 8000:8000 cc-backend
-curl -s http://localhost:8000/healthz
+docker run --rm -e SAFE_MODE=1 -p 8000:8000 cc-backend
+curl -sSf http://localhost:8000/healthz
 ```
 
 Ports: BE 8000 ; FE 5173 ; DB 5432 ; Redis 6379 ; Adminer 8080 ; Prom 9090 ; Grafana 3000 ; Mailpit 8025.

--- a/backend/README.md
+++ b/backend/README.md
@@ -24,6 +24,11 @@ Le packaging est limite au package `app` (Alembic exclu).
   * Ports: 8000 expose
 * Sante: `/health` et `/healthz` -> 200
 
+## Docker SAFE_MODE
+
+* L image par defaut sert les endpoints de sante avec `SAFE_MODE=1`.
+* Forcer le mode complet (dev): `-e SAFE_MODE=0` (necessitera deps projet complètes dans une image future).
+
 Tests (PS + curl):
 
 * Typage: `python tools/mypy_backend.py`


### PR DESCRIPTION
## Summary
- remove editable backend install in Dockerfile; install minimal FastAPI/Uvicorn deps for SAFE_MODE
- document SAFE_MODE Docker usage in root and backend READMEs

## Testing
- `pwsh -NoLogo -NoProfile -c "docker build -t cc-backend .; docker run --rm -e SAFE_MODE=1 -p 8000:8000 cc-backend & Start-Sleep 3; curl -sf http://localhost:8000/healthz; exit $LASTEXITCODE"` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b727b865688330a4e093581500218f