### PR TITLE
perf-k6: SAFE_MODE micro-app /healthz + CMD conditionnel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,19 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Deps minimales pour SAFE_MODE (/healthz)
-
-# Pins stables pour reproductibilite CI
+# Deps minimales pour servir /healthz
 
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir fastapi==0.115.0 uvicorn==0.30.6
 
-# Code backend (routes lourdes protegees par SAFE_MODE)
+# Code necessaire
 
+COPY deploy/ deploy/
 COPY backend/ backend/
 
 EXPOSE 8000
-CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+# Si SAFE_MODE=1 => micro-app /healthz (independante du backend)
+# Sinon => backend complet
+
+CMD ["/bin/sh","-lc","if [ \"$SAFE_MODE\" = \"1\" ]; then uvicorn deploy.k6.health_app:app --host 0.0.0.0 --port 8000; else uvicorn backend.app.main:app --host 0.0.0.0 --port 8000; fi"]

--- a/README.md
+++ b/README.md
@@ -25,28 +25,24 @@ pwsh -NoLogo -NoProfile -File PS1/smoke.ps1
 
 ## Mode SAFE (docker-smoke)
 
-* Le container par defaut est lance avec `SAFE_MODE=1` pour garantir `/health` et `/healthz` sans charger les routes lourdes.
+* Le container par defaut est lance avec `SAFE_MODE=1` pour servir une micro-app `/health` et `/healthz` sans charger les routes lourdes.
 * En production/dev complet, retirer `SAFE_MODE` (ou `SAFE_MODE=0`) pour charger toutes les routes.
 
-## Docker (backend)
+## Docker (SAFE_MODE et perf-k6)
 
-* Port: 8000 expose
-* CMD: `uvicorn backend.app.main:app --host 0.0.0.0 --port 8000`
-* `PYTHONPATH=/app/backend` pour resoudre `backend.app.*`
+* L'image par défaut lance une micro-app de santé quand `SAFE_MODE=1`:
 
-## Docker (SAFE_MODE)
+  * Endpoints: `/health`, `/healthz` → `{"status":"ok"}`
+  * Utilisé par `docker-smoke` et `perf-k6` pour une vérification robuste.
+* Pour lancer le backend complet: `docker run -e SAFE_MODE=0 -p 8000:8000 cc-backend`.
 
-* Image de smoke: deps minimales (FastAPI+Uvicorn), `SAFE_MODE=1` par defaut -> seules `/health` et `/healthz`.
-* Lancer:
+Commandes:
 
 ```
 docker build -t cc-backend .
 docker run --rm -e SAFE_MODE=1 -p 8000:8000 cc-backend
 curl -sSf http://localhost:8000/healthz
 ```
-
-Ports: BE 8000 ; FE 5173 ; DB 5432 ; Redis 6379 ; Adminer 8080 ; Prom 9090 ; Grafana 3000 ; Mailpit 8025.
-Voir `deploy/README.md` pour details (compose, observabilite). Roadmap: relire `docs/roadmap.md`.
 
 ## Perf baseline (J20)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,7 +12,7 @@ Le packaging est limite au package `app` (Alembic exclu).
 ## Sante et SAFE_MODE
 
 * `/health` et `/healthz` -> 200.
-* `SAFE_MODE=1` (par defaut dans l'image) : seules les routes de sante sont actives.
+* `SAFE_MODE=1` (par defaut dans l'image) : sert une micro-app FastAPI (`deploy/k6/health_app.py`) avec seulement les routes de sante.
 * `SAFE_MODE=0` : routes API chargees (`/api/v1/...`).
 * Uvicorn ecoute 0.0.0.0:8000 (Docker: EXPOSE 8000)
 
@@ -26,7 +26,7 @@ Le packaging est limite au package `app` (Alembic exclu).
 
 ## Docker SAFE_MODE
 
-* L image par defaut sert les endpoints de sante avec `SAFE_MODE=1`.
+* L image par defaut sert une micro-app de sante avec `SAFE_MODE=1`.
 * Forcer le mode complet (dev): `-e SAFE_MODE=0` (necessitera deps projet complètes dans une image future).
 
 Tests (PS + curl):

--- a/deploy/k6/health_app.py
+++ b/deploy/k6/health_app.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI(title="Health App (SAFE_MODE)")
+
+
+@app.get("/health")
+def health() -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
+
+@app.get("/healthz")
+def healthz() -> JSONResponse:
+    return JSONResponse({"status": "ok"})


### PR DESCRIPTION
## Summary
- serve dedicated FastAPI health micro-app when SAFE_MODE=1
- add conditional CMD in Dockerfile to choose micro-app or full backend
- document SAFE_MODE behaviour for perf-k6

## Testing
- `docker build -t cc-backend .` *(fails: Cannot connect to the Docker daemon)*
- `docker run --rm -e SAFE_MODE=1 -p 8000:8000 cc-backend` *(fails: Cannot connect to the Docker daemon)*
- `curl -sf http://localhost:8000/healthz` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68b72ae63fbc8330ae3a114fc76f03b7