### PR TITLE
CI: frontend.yml sans runs vides (paths filters + concurrency)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,8 +5,13 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend.yml"
-      - "package.json"
-      - "package-lock.json"
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+  workflow_dispatch: {}
 
 concurrency:
   group: frontend-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ Rien de specifique pour les E2E Storybook (pas de secrets).
 * Frontend dev: 5173
 * Storybook E2E (serve): 6006
 
+## CI - Frontend: declencheurs et bruit
+
+* Le workflow **frontend (lint+unit+e2e-smoke)** ne se lance que si des fichiers sous `frontend/**` (ou le fichier du workflow) changent.
+* Objectif: eviter les runs vides et les emails "No jobs were run".
+* `concurrency` est active pour annuler les runs precedents sur la meme ref.
+
 ## Tests/Lint
 
 ```powershell


### PR DESCRIPTION
## Summary
- avoid empty frontend workflows via top-level path filters
- document frontend CI triggers and concurrency

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68b72e54b1008330bd1d2912776c68ff