### PR TITLE
CI: frontend.yml - eviter runs vides (pull_request strict)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,16 +2,10 @@ name: frontend (lint+unit+e2e-smoke)
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
     paths:
       - "frontend/**"
       - ".github/workflows/frontend.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "frontend/**"
-      - ".github/workflows/frontend.yml"
-  workflow_dispatch: {}
 
 concurrency:
   group: frontend-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -270,11 +270,11 @@ Rien de specifique pour les E2E Storybook (pas de secrets).
 * Frontend dev: 5173
 * Storybook E2E (serve): 6006
 
-## CI - Frontend: declencheurs et bruit
+## CI - Frontend
 
-* Le workflow **frontend (lint+unit+e2e-smoke)** ne se lance que si des fichiers sous `frontend/**` (ou le fichier du workflow) changent.
-* Objectif: eviter les runs vides et les emails "No jobs were run".
-* `concurrency` est active pour annuler les runs precedents sur la meme ref.
+* Le workflow **frontend (lint+unit+e2e-smoke)** ne se lance que sur **pull_request** quand des fichiers sous `frontend/**` (ou le fichier du workflow) changent.
+* Objectif: supprimer les runs vides et les emails "No jobs were run".
+* `concurrency` annule les runs precedents sur la meme ref.
 
 ## Tests/Lint
 


### PR DESCRIPTION
## Summary
- avoid empty runs by restricting frontend workflow to pull_request (types+paths)
- document frontend workflow triggers

## Testing
- `bash tools/docs_guard.sh`
- `bash tools/readme_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b731190c1c833088d8879535bf00d9