### PR TITLE
Jalon 21 - Staging infra (compose+Caddy TLS+volumes+health+CI)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,31 @@
+name: deploy-staging
+on:
+  workflow_dispatch:
+    inputs:
+      env_file:
+        description: "Chemin .env staging sur runner"
+        required: false
+        default: "deploy/staging/.env"
+jobs:
+  deploy:
+    runs-on: self-hosted
+    environment: staging
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker login (optional registry)
+        if: ${{ false }}
+        run: echo "Skip registry login; zero secret policy"
+      - name: Deploy compose up
+        shell: pwsh
+        run: |
+          cd deploy/staging
+          ./deploy_up.ps1 -EnvFile "${{ github.event.inputs.env_file }}"
+      - name: Smoke
+        shell: pwsh
+        env:
+          STAGING_DOMAIN: ${{ vars.STAGING_DOMAIN }}
+        run: |
+          cd deploy/staging
+          ./smoke.ps1 -BaseUrl ("https://{0}" -f $Env:STAGING_DOMAIN)

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -1,0 +1,22 @@
+name: zap-baseline
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
+jobs:
+  zap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ZAP baseline
+        run: |
+          mkdir -p artifacts
+          docker run --rm -v "$PWD/artifacts:/zap/wrk" ghcr.io/zaproxy/zaproxy:stable zap-baseline.py\
+          -t "https://${{ vars.STAGING_DOMAIN }}"\
+          -x zap_report.xml -w zap_report.md -r zap_report.html || true
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-baseline
+          path: artifacts/*

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ curl -sSf http://localhost:8000/healthz
   * `fe-bundle-budget` (bloquant si depasse budget)
 * Endpoints relies: `/healthz` (baseline rapide). Voir backend/README.md.
 
+## Staging
+
+* Dossier: deploy/staging
+* Demarrage: PowerShell
+  cd deploy/staging
+  ./deploy_up.ps1 -EnvFile ".env"
+* Test rapide:
+  $Env:STAGING_DOMAIN="staging.example.com"
+  ./smoke.ps1 -BaseUrl ("https://{0}" -f $Env:STAGING_DOMAIN)
+* CI:
+  * deploy-staging (manuel, runner self-hosted)
+  * zap-baseline (manuel + hebdo)
+
+ENV requis (.env staging sur VM):
+
+* BACKEND_IMAGE, FRONTEND_IMAGE
+* POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD, DATABASE_URL
+* REDIS_URL
+* STAGING_DOMAIN, ACME_EMAIL
+
 ## CI Python (lint + typing)
 
 * **Ruff**: `python -m ruff check backend`

--- a/deploy/staging/.env.example
+++ b/deploy/staging/.env.example
@@ -1,0 +1,20 @@
+# Images a builder/pusher en amont (CI) ou reference registry
+BACKEND_IMAGE=ghcr.io/owner/repo/backend:staging
+FRONTEND_IMAGE=ghcr.io/owner/repo/frontend:staging
+
+# Base de donnees
+POSTGRES_DB=cc_staging
+POSTGRES_USER=cc_user
+POSTGRES_PASSWORD=change_me
+DATABASE_URL=postgresql+psycopg://cc_user:change_me@db:5432/cc_staging
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+
+# Caddy / ACME
+STAGING_DOMAIN=staging.example.com
+ACME_EMAIL=admin@example.com
+
+# Divers
+TZ=UTC
+PYTHONHASHSEED=0

--- a/deploy/staging/Caddyfile
+++ b/deploy/staging/Caddyfile
@@ -1,0 +1,40 @@
+{
+email ${ACME_EMAIL}
+admin 0.0.0.0:2019
+}
+
+${STAGING_DOMAIN} {
+encode gzip
+@api path /api/* /api/v1/* /healthz
+handle @api {
+reverse_proxy backend:8000
+}
+
+@assets path /assets/* /favicon.ico
+handle @assets {
+reverse_proxy frontend:5173
+}
+
+# Frontend app (SPA)
+
+route {
+reverse_proxy frontend:5173
+}
+
+# Static health endpoint for LB/probes
+
+handle_path /healthz {
+respond "ok" 200
+}
+
+tls {
+issuer acme
+}
+
+header {
+X-Frame-Options "DENY"
+X-Content-Type-Options "nosniff"
+Referrer-Policy "no-referrer-when-downgrade"
+Content-Security-Policy "default-src 'self' https: data: 'unsafe-inline' 'unsafe-eval'"
+}
+}

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -1,0 +1,32 @@
+# Staging (compose + Caddy)
+
+Prerequis:
+
+* DNS A/AAAA -> VM publique (ports 80/443 ouverts)
+* Docker/Compose installs
+* Fichier .env base sur .env.example, stocke sur la VM (non commit)
+
+Commandes:
+
+* Demarrer: PowerShell
+  cd deploy/staging
+  ./deploy_up.ps1 -EnvFile ".env"
+* Arreter:
+  ./deploy_down.ps1
+* Smoke:
+  $Env:STAGING_DOMAIN="staging.example.com"
+  ./smoke.ps1 -BaseUrl ("https://{0}" -f $Env:STAGING_DOMAIN)
+
+Health:
+
+* FE: GET /
+* Static: GET /healthz
+* API: GET /api/v1/health
+
+Volumes:
+
+* db_data, redis_data, caddy_data, caddy_config
+
+TLS:
+
+* Lets Encrypt via Caddy (email ACME_EMAIL)

--- a/deploy/staging/compose.yaml
+++ b/deploy/staging/compose.yaml
@@ -1,0 +1,97 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16.4
+    container_name: cc_staging_db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      TZ: UTC
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB" ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7.4-alpine
+    container_name: cc_staging_redis
+    restart: unless-stopped
+    command: [ "redis-server", "--appendonly", "yes" ]
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    image: ${BACKEND_IMAGE}
+    container_name: cc_staging_backend
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
+      UVICORN_HOST: 0.0.0.0
+      UVICORN_PORT: 8000
+      TZ: UTC
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -fsS http://localhost:8000/healthz || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+  frontend:
+    image: ${FRONTEND_IMAGE}
+    container_name: cc_staging_frontend
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      TZ: UTC
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -fsS http://localhost:5173/ || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+  caddy:
+    image: caddy:2.8.4
+    container_name: cc_staging_caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      ACME_AGREE: "true"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:2019/config || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  db_data:
+  redis_data:
+  caddy_data:
+  caddy_config:

--- a/deploy/staging/deploy_down.ps1
+++ b/deploy/staging/deploy_down.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Push-Location $here
+docker compose -f compose.yaml down
+Pop-Location
+exit 0

--- a/deploy/staging/deploy_up.ps1
+++ b/deploy/staging/deploy_up.ps1
@@ -1,0 +1,25 @@
+Param(
+    [string]$EnvFile = ".env"
+)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Push-Location $here
+if (!(Test-Path $EnvFile)) { Write-Error "Fichier $EnvFile manquant" ; exit 2 }
+Write-Host "[INFO] Chargement env depuis $EnvFile"
+$envLines = Get-Content $EnvFile | Where-Object {$_ -and $_ -notmatch "^#"}
+foreach ($line in $envLines) { $k,$v = $line -split "=",2 ; if ($k) { [Environment]::SetEnvironmentVariable($k,$v) } }
+Write-Host "[INFO] Docker compose up -d"
+docker compose -f compose.yaml --env-file $EnvFile up -d --remove-orphans
+Write-Host "[INFO] Attente sante services..."
+$retries = 60
+while ($retries -gt 0) {
+    $health = docker ps --format "{{.Names}} {{.Status}}" | Select-String "healthy"
+    if ($health -and ($health.ToString() -match "backend") -and ($health.ToString() -match "frontend") -and ($health.ToString() -match "caddy")) { break }
+    Start-Sleep -Seconds 5
+    $retries--
+}
+if ($retries -le 0) { Write-Error "Services non healthy" ; exit 3 }
+Write-Host "[OK] Staging demarre."
+Pop-Location
+exit 0

--- a/deploy/staging/smoke.ps1
+++ b/deploy/staging/smoke.ps1
@@ -1,0 +1,15 @@
+Param(
+    [Parameter(Mandatory=$true)][string]$BaseUrl
+)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+function Test-Url($u) {
+    try { (Invoke-WebRequest -Uri $u -UseBasicParsing -TimeoutSec 10).StatusCode } catch { -1 }
+}
+$fe = Test-Url "$BaseUrl/"
+$hz = Test-Url "$BaseUrl/healthz"
+$be = Test-Url "$BaseUrl/api/v1/health"
+Write-Host "FE: $fe | /healthz: $hz | API: $be"
+if ($fe -ne 200 -or $hz -ne 200 -or $be -ne 200) { Write-Error "Smoke KO" ; exit 4 }
+Write-Host "Smoke OK"
+exit 0

--- a/docs/STAGING_RUNBOOK.md
+++ b/docs/STAGING_RUNBOOK.md
@@ -1,0 +1,54 @@
+# Runbook Staging
+
+Objectif: Expliquer le cycle de vie staging: DNS/TLS, deploiement, rollback, sauvegardes, securite, scans.
+
+1. DNS/TLS
+
+* Variable STAGING_DOMAIN pointe sur VM.
+* Caddy gere ACME; ports 80/443 requis.
+* ACME_EMAIL doit etre valide.
+
+2. Deploiement
+
+* Runner self-hosted sur VM.
+* Lancer workflow "deploy-staging".
+* Images FRONTEND_IMAGE/BACKEND_IMAGE deja poussees au registry.
+* Compose attend les health checks avant d exposer Caddy.
+
+3. Verification
+
+* Smoke:
+  $Env:STAGING_DOMAIN="staging.example.com"
+  deploy/staging/smoke.ps1 -BaseUrl ("https://{0}" -f $Env:STAGING_DOMAIN)
+
+4. Scans ZAP
+
+* Lancer workflow "zap-baseline" ou attendre CRON hebdomadaire.
+* Recuperer artifact zap-baseline (html/xml/md).
+* Traiter alertes Medium+.
+
+5. Backups/Restore
+
+* Postgres: volume db_data. Faire dump regulier (pg_dump) via job hors scope present fiche.
+* Redis: AOF dans redis_data.
+
+6. Rollback
+
+* Revenir a images N-1 en ajustant BACKEND_IMAGE/FRONTEND_IMAGE dans .env puis redeployer.
+* Si schema DB casse, appliquer rollback via Alembic (commande hors scope ici).
+
+7. Journalisation/Observabilite
+
+* Logs docker: docker logs -f cc_staging_backend
+* request_id et logs JSON (selon app).
+* Ajout Grafana/OTel (optionnel futur jalon).
+
+8. Securite
+
+* npm audit/pip-audit en CI deja en place (global).
+* Gitleaks, SBOM CycloneDX recommandes sur images.
+
+9. Incidents
+
+* Fe 502: verifier health backend. docker ps, docker logs.
+* ACME echec: verifier ports 80/443 et DNS propagation.

--- a/tools/zap_baseline.ps1
+++ b/tools/zap_baseline.ps1
@@ -1,0 +1,11 @@
+Param(
+    [Parameter(Mandatory=$true)][string]$Target,
+    [string]$Out = "zap_report.html"
+)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+Write-Host "[INFO] Lancement ZAP baseline sur $Target"
+docker run --rm -v ${PWD}:/zap/wrk ghcr.io/zaproxy/zaproxy:stable zap-baseline.py -t $Target -x zap_report.xml -w zap_report.md -r $Out
+if (!(Test-Path $Out)) { Write-Error "Rapport ZAP manquant" ; exit 4 }
+Write-Host "[OK] Rapport genere: $Out"
+exit 0


### PR DESCRIPTION
## Summary
- add staging docker compose stack with Caddy TLS, Postgres, Redis, and health checks
- provide PowerShell scripts for deploy, teardown, smoke test, and ZAP baseline
- document staging usage and runbook and wire manual GitHub workflows

## Testing
- `pwsh -NoProfile -Command "Get-ChildItem deploy/staging/*.ps1, tools/zap_baseline.ps1 | % { }"` *(fails: command not found)*
- `curl -fsSL https://staging.example.com/healthz` *(fails: 403)*
- `curl -fsSL https://staging.example.com/api/v1/health` *(fails: 403)*
- `pwsh -File tools/zap_baseline.ps1 -Target https://staging.example.com` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b734798e64833098313d993e467eed